### PR TITLE
add `inverseOf` to context

### DIFF
--- a/context.jsonld
+++ b/context.jsonld
@@ -12,6 +12,7 @@
     "labelMap": { "@id": "skos:prefLabel", "@container": "@language" },
     "note": "skos:note",
     "noteMap": { "@id": "skos:note", "@container": "@language" },
+    "inverseOf": "owl:inverseOf",
     "subject": { "@id": "vf:subject", "@type": "@id" },
     "relationship": { "@id": "vf:relationship", "@type": "@id" },
     "object": { "@id": "vf:object", "@type": "@id" }


### PR DESCRIPTION
we're using it in our examples of relationships, as well as our prototype apps, so here's a proposal to add it to our `@context`.

relevant discussion: https://github.com/valueflows/valueflows/issues/52.