### PR TITLE
clearer I/O relation between Process and I/C/E

### DIFF
--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -22,8 +22,8 @@ vf:ResourceTemplate  a           owl:Class ;
 vf:ProcessTemplate  a           owl:Class ;
         rdfs:label           "vf:ProcessTemplate" .
 
-vf:EventTemplate  a           owl:Class ;
-        rdfs:label           "vf:EventTemplate" .
+vf:IntentTemplate  a           owl:Class ;
+        rdfs:label           "vf:IntentTemplate" .
 
 vf:ExchangeTemplate  a           owl:Class ;
         rdfs:label           "vf:ExchangeTemplate" .
@@ -125,32 +125,22 @@ vf:Currency  a           owl:Class ;
 
 vf:action
         a                   owl:ObjectProperty ;
-        rdfs:domain         vf:EventTemplate , vf:Intent , vf:Commitment , vf:Event ;
+        rdfs:domain         vf:IntentTemplate , vf:Intent , vf:Commitment , vf:Event ;
         rdfs:range          vf:Action .
 
 vf:inputOf
         a                   owl:ObjectProperty ;
-        rdfs:domain         vf:EventTemplate , vf:Event ;
-        rdfs:range          vf:ProcessTemplate , vf:Process .
+        rdfs:domain         vf:Event ;
+        rdfs:range          vf:Process .
 
 vf:outputOf
         a                   owl:ObjectProperty ;
-        rdfs:domain         vf:EventTemplate , vf:Event ;
-        rdfs:range          vf:ProcessTemplate , vf:Process .
+        rdfs:domain         vf:Event ;
+        rdfs:range          vf:Process .
 
 vf:commitedInputOf
         a                   owl:ObjectProperty ;
         rdfs:domain         vf:Commitment ;
-        rdfs:range          vf:Process .
-
-vf:intendedOutputOf
-        a                   owl:ObjectProperty ;
-        rdfs:domain         vf:Intent ;
-        rdfs:range          vf:Process .
-
-vf:intendedInputOf
-        a                   owl:ObjectProperty ;
-        rdfs:domain         vf:Intent ;
         rdfs:range          vf:Process .
 
 vf:commitedOutputOf
@@ -158,10 +148,30 @@ vf:commitedOutputOf
         rdfs:domain         vf:Commitment ;
         rdfs:range          vf:Process .
 
-vf:eventTemplate
+vf:intendedInputOf
+        a                   owl:ObjectProperty ;
+        rdfs:domain         vf:Intent ;
+        rdfs:range          vf:Process .
+
+vf:templatedOutputOf
+        a                   owl:ObjectProperty ;
+        rdfs:domain         vf:IntentTemplate ;
+        rdfs:range          vf:ProcessTemplate .
+
+vf:templatedInputOf
+        a                   owl:ObjectProperty ;
+        rdfs:domain         vf:IntentTemplate ;
+        rdfs:range          vf:ProcessTemplate .
+
+vf:intendedOutputOf
+        a                   owl:ObjectProperty ;
+        rdfs:domain         vf:Intent ;
+        rdfs:range          vf:Process .
+
+vf:intentTemplate
         a                   owl:ObjectProperty ;
         rdfs:domain         vf:Intent , vf:Commitment ;
-        rdfs:range          vf:EventTemplate .
+        rdfs:range          vf:IntentTemplate .
 
 vf:processTemplate
         a                   owl:ObjectProperty ;
@@ -184,7 +194,7 @@ vf:parent
 
 vf:hasResourceTemplate
         a                   owl:ObjectProperty ;
-        rdfs:domain         vf:Resource , vf:EventTemplate , vf:Intent , vf:Commitment ;
+        rdfs:domain         vf:Resource , vf:IntentTemplate , vf:Intent , vf:Commitment ;
         rdfs:range          vf:ResourceTemplate .
 
 vf:involveResource

--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -128,14 +128,34 @@ vf:action
         rdfs:domain         vf:EventTemplate , vf:Intent , vf:Commitment , vf:Event ;
         rdfs:range          vf:Action .
 
-vf:occursIn
+vf:inputOf
         a                   owl:ObjectProperty ;
         rdfs:domain         vf:EventTemplate , vf:Event ;
         rdfs:range          vf:ProcessTemplate , vf:Process .
 
-vf:willOccurIn
+vf:outputOf
         a                   owl:ObjectProperty ;
-        rdfs:domain         vf:Intent , vf:Commitment ;
+        rdfs:domain         vf:EventTemplate , vf:Event ;
+        rdfs:range          vf:ProcessTemplate , vf:Process .
+
+vf:commitedInputOf
+        a                   owl:ObjectProperty ;
+        rdfs:domain         vf:Commitment ;
+        rdfs:range          vf:Process .
+
+vf:intendedOutputOf
+        a                   owl:ObjectProperty ;
+        rdfs:domain         vf:Intent ;
+        rdfs:range          vf:Process .
+
+vf:intendedInputOf
+        a                   owl:ObjectProperty ;
+        rdfs:domain         vf:Intent ;
+        rdfs:range          vf:Process .
+
+vf:commitedOutputOf
+        a                   owl:ObjectProperty ;
+        rdfs:domain         vf:Commitment ;
         rdfs:range          vf:Process .
 
 vf:eventTemplate


### PR DESCRIPTION
this PR IMO simplifies Input/Output relationships between Processes and Intents/Commitments/Events

Instead of relying on interpretation of 'action verb' the which relates Intent/Commitment/Event to a Process itself captures the input/output aspect.

Since we consider defining service as Intent/Commitment/Event which can reference two processes
* one as *outputOf*
* other as *inputOf*
Approach below makes it possible, since in case where we need to relatet I/C/E to two processes we can't just rely on 'action verb'.

Not sure if we need distinct properties for Intent, Commitment and Event or enough to just have *inputOf* & *outputOf* and rely on the type of instance using them to make distinction between Intent, Commitment and Event expressing Inputs and Outputs.