### PR TITLE
quantities used by Intent/Commitment/Event

### DIFF
--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -239,6 +239,36 @@ vf:decrementQuantity
         rdfs:domain         vf:Event ;
         rdfs:range          qudt:QuantityValue .
 
+vf:commitedIncrementQuantity
+        a                   owl:ObjectProperty ;
+        rdfs:domain         vf:Commitment ;
+        rdfs:range          qudt:QuantityValue .
+
+vf:commitedDecrementQuantity
+        a                   owl:ObjectProperty ;
+        rdfs:domain         vf:Commitment ;
+        rdfs:range          qudt:QuantityValue .
+
+vf:intendedIncrementQuantity
+        a                   owl:ObjectProperty ;
+        rdfs:domain         vf:Intent ;
+        rdfs:range          qudt:QuantityValue .
+
+vf:intendedDecrementQuantity
+        a                   owl:ObjectProperty ;
+        rdfs:domain         vf:Intent ;
+        rdfs:range          qudt:QuantityValue .
+
+vf:templatedIncrementQuantity
+        a                   owl:ObjectProperty ;
+        rdfs:domain         vf:IntentTemplate ;
+        rdfs:range          qudt:QuantityValue .
+
+vf:templatedDecrementQuantity
+        a                   owl:ObjectProperty ;
+        rdfs:domain         vf:IntentTemplate ;
+        rdfs:range          qudt:QuantityValue .
+
 vf:appreciationOf
         a                   owl:ObjectProperty ;
         rdfs:domain         vf:Appreciation ;

--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -6,6 +6,7 @@
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix foaf:  <http://xmlns.com/foaf/0.1/#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
 
 
 <https://w3id.org/valueflows/> a owl:Ontology;
@@ -227,6 +228,16 @@ vf:affects
         a                   owl:ObjectProperty ;
         rdfs:domain         vf:Event ;
         rdfs:range          vf:Resource .
+
+vf:incrementQuantity
+        a                   owl:ObjectProperty ;
+        rdfs:domain         vf:Event ;
+        rdfs:range          qudt:QuantityValue .
+
+vf:decrementQuantity
+        a                   owl:ObjectProperty ;
+        rdfs:domain         vf:Event ;
+        rdfs:range          qudt:QuantityValue .
 
 vf:appreciationOf
         a                   owl:ObjectProperty ;

--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -30,7 +30,7 @@ vf:ExchangeTemplate  a           owl:Class ;
         rdfs:label           "vf:ExchangeTemplate" .
 
 vf:Action  a           owl:Class ;
-        rdfs:label           "vf:Action"
+        rdfs:label           "vf:Action" ;
         rdfs:subClassOf   rdf:Property .
 
 # PLAN CLASSES
@@ -230,42 +230,42 @@ vf:affects
         rdfs:range          vf:Resource .
 
 vf:incrementQuantity
-        a                   owl:ObjectProperty ;
+        a                   owl:ObjectProperty, owl:FunctionalProperty ;
         rdfs:domain         vf:Event ;
         rdfs:range          qudt:QuantityValue .
 
 vf:decrementQuantity
-        a                   owl:ObjectProperty ;
+        a                   owl:ObjectProperty, owl:FunctionalProperty ;
         rdfs:domain         vf:Event ;
         rdfs:range          qudt:QuantityValue .
 
 vf:commitedIncrementQuantity
-        a                   owl:ObjectProperty ;
+        a                   owl:ObjectProperty, owl:FunctionalProperty ;
         rdfs:domain         vf:Commitment ;
         rdfs:range          qudt:QuantityValue .
 
 vf:commitedDecrementQuantity
-        a                   owl:ObjectProperty ;
+        a                   owl:ObjectProperty, owl:FunctionalProperty ;
         rdfs:domain         vf:Commitment ;
         rdfs:range          qudt:QuantityValue .
 
 vf:intendedIncrementQuantity
-        a                   owl:ObjectProperty ;
+        a                   owl:ObjectProperty, owl:FunctionalProperty ;
         rdfs:domain         vf:Intent ;
         rdfs:range          qudt:QuantityValue .
 
 vf:intendedDecrementQuantity
-        a                   owl:ObjectProperty ;
+        a                   owl:ObjectProperty, owl:FunctionalProperty ;
         rdfs:domain         vf:Intent ;
         rdfs:range          qudt:QuantityValue .
 
 vf:templatedIncrementQuantity
-        a                   owl:ObjectProperty ;
+        a                   owl:ObjectProperty, owl:FunctionalProperty ;
         rdfs:domain         vf:IntentTemplate ;
         rdfs:range          qudt:QuantityValue .
 
 vf:templatedDecrementQuantity
-        a                   owl:ObjectProperty ;
+        a                   owl:ObjectProperty, owl:FunctionalProperty ;
         rdfs:domain         vf:IntentTemplate ;
         rdfs:range          qudt:QuantityValue .
 


### PR DESCRIPTION
First commit proposes *vf:incrementQuantity* and *vf:decrementQuantity*. Using those distinct properties we don't need to rely on 'action verb' to know if resource referenced with *vf:affects* should get incremented or decremented.

Similar to #191 we need to figure out if we want to use same properties on Intent/Commitment/Event all call them differently *eg *vf:incrementedQuantity*, *vf:commitedIncrementQuantity*, *vf:intendedIncrementQuantity*.

Most likely we also need to do the same for *vf:affects* - reuse on Intent/Commitment/Event or define variants of this property for each one.