### PR TITLE
change how flows reference agents

### DIFF
--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -265,7 +265,7 @@ vf:appreciationWith
         rdfs:range          vf:EconomicEvent ;
         rdfs:comment        "The economic event implemented in appreciation (gift economy)." .
 
-vf:commitedBy  a     owl:ObjectProperty ;
+vf:committedBy  a     owl:ObjectProperty ;
         rdfs:domain  vf:Commitment ;
         rdfs:label   "commitedBy" ;
         rdfs:range   foaf:Agent ;
@@ -277,7 +277,7 @@ vf:performedBy  a    owl:ObjectProperty ;
         rdfs:range   foaf:Agent ;
         rdfs:comment "The economic agent performs the action." .
 
-vf:commitedTo  a     owl:ObjectProperty ;
+vf:committedTo  a     owl:ObjectProperty ;
         rdfs:domain  vf:Commitment ;
         rdfs:label   "commitedTo" ;
         rdfs:range   foaf:Agent ;

--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -40,7 +40,7 @@ vf:ProcessClassification  a           owl:Class ;
 vf:ExchangeClassification  a           owl:Class ;
         rdfs:label           "vf:ExchangeClassification" ;
         rdfs:comment   "An exchange category, model, taxonomy item, tag, facet value, or other kind of classification." .
-        
+
 # PLAN CLASSES
 
 #vf:Intent  a       owl:Class ;
@@ -221,7 +221,7 @@ vf:exchangeClassifiedAs
 vf:involves
         a                   owl:ObjectProperty ;
         rdfs:label         "involves" ;
-        rdfs:domain         vf:Commitment ; 
+        rdfs:domain         vf:Commitment ;
         rdfs:range          vf:EconomicResource ;
         rdfs:comment        "EconomicResource the Commitment intends or commits to affect. Could be an actual resource or a category or type of resource." .
 
@@ -265,17 +265,29 @@ vf:appreciationWith
         rdfs:range          vf:EconomicEvent ;
         rdfs:comment        "The economic event implemented in appreciation (gift economy)." .
 
-vf:provider  a       owl:ObjectProperty ;
-        rdfs:domain  [ owl:unionOf (vf:EconomicEvent vf:Commitment) ] ;
-        rdfs:label   "provider" ;
+vf:commitedBy  a     owl:ObjectProperty ;
+        rdfs:domain  vf:Commitment ;
+        rdfs:label   "commitedBy" ;
         rdfs:range   foaf:Agent ;
-        rdfs:comment        "The economic agent from whom the intended, committed, or actual economic event is initiated." .
+        rdfs:comment "The economic agent who makes the commitment." .
 
-vf:receiver  a       owl:ObjectProperty ;
-        rdfs:domain  [ owl:unionOf (vf:EconomicEvent vf:Commitment) ] ;
-        rdfs:label   "receiver" ;
+vf:performedBy  a    owl:ObjectProperty ;
+        rdfs:domain  vf:EconomicEvent ;
+        rdfs:label   "performedBy" ;
         rdfs:range   foaf:Agent ;
-        rdfs:comment        "The economic agent whom the intended, committed, or actual economic event is for." .
+        rdfs:comment "The economic agent performs the action." .
+
+vf:commitedTo  a     owl:ObjectProperty ;
+        rdfs:domain  vf:Commitment ;
+        rdfs:label   "commitedTo" ;
+        rdfs:range   foaf:Agent ;
+        rdfs:comment "The economic agent who holds the agent who made the commitment accountable." .
+
+vf:requestedBy  a    owl:ObjectProperty ;
+        rdfs:domain  vf:EconomicEvent ;
+        rdfs:label   "requestedBy" ;
+        rdfs:range   foaf:Agent ;
+        rdfs:comment "The economic agent requested action to happen" .
 
 vf:subject  a        owl:ObjectProperty ;
         rdfs:domain  vf:AgentRelationship ;
@@ -302,7 +314,7 @@ vf:scope  a          owl:ObjectProperty ;
         rdfs:comment        "The larger boundary or context, used for documenting, accounting, planning, distributing income." .
 
 vf:under  a          owl:ObjectProperty ;
-        rdfs:domain  [ owl:unionOf (vf:EconomicEvent vf:Commitment vf:Reciprocity vf:Fulfillment) ] ; 
+        rdfs:domain  [ owl:unionOf (vf:EconomicEvent vf:Commitment vf:Reciprocity vf:Fulfillment) ] ;
         rdfs:label   "under" ;
         rdfs:range   vf:Agreement ;
         rdfs:comment        "Reference an agreement between agents which specifies the rules or policies which govern this event." .
@@ -398,8 +410,8 @@ vf:note a owl:ObjectProperty ;
 
 vf:trackingIdentifier a owl:AnnotationProperty ;
         rdfs:label "tracking identifier" ;
-        rdfs:domain     vf:EconomicResource ;   
-        rdfs:comment    "Sometimes called lot number, used for trackable batched resources. Sometimes called serial number, used when each item must have a trackable identifier (like a computer). Could also be used for other unique tracking identifiers needed for resources." .  
+        rdfs:domain     vf:EconomicResource ;
+        rdfs:comment    "Sometimes called lot number, used for trackable batched resources. Sometimes called serial number, used when each item must have a trackable identifier (like a computer). Could also be used for other unique tracking identifiers needed for resources." .
 
 vf:fulfilledBy          a owl:ObjectProperty ;
         rdfs:label      "fulfilled by" ;
@@ -414,7 +426,7 @@ vf:fulfills     a owl:ObjectProperty ;
         rdfs:comment    "The commitment which is completely or partially fulfilled by an economic event." .
 
 #vf:isFinished  a        owl:DataTypeProperty ;
-#        rdfs:domain     [ owl:unionOf (vf:Commitment vf:Process) ] ; 
+#        rdfs:domain     [ owl:unionOf (vf:Commitment vf:Process) ] ;
 #        rdfs:label      "is finished" ;
 #        rdfs:range      xsd:boolean ;
 #        rdfs:comment    "The commitment or process is complete or not." .


### PR DESCRIPTION
Since we look at more sophisticated mechanism to address rights and responsibilities. I thought this change may clarify how agents relate to flows, in particular Commitment and Event. If diff dosn't make it clear, changes boil down to replacing:
* `vf:provider`
  * `vf:commitedBy` in `vf:Commitment`
  * `vf:performedBy` in `vf:EconomicEvent`
* `vf:receiver`
  * `vf:commitedBy` in `vf:Commitment`
  * `vf:requestedBy` in `vf:EconomicEvents`

I don't think currently terminology made it clear that
* *provider* makes the commitment and then performs the action carried out in event
* *receiver* holds agent who made commitment accountable and requests the action carried out in event

In cases like handling by products, the *receiver* of the by product would probably make the commitment to receive it, not the *provider*.