### PR TITLE
exchange rates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm-debug.log
 
 .build
 *~
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "mdast": "^2.1.0",
     "mdast-autolink-headings": "^1.0.0",
     "mdast-html": "^1.2.1",
-    "mdast-slug": "^2.0.0"
+    "mdast-slug": "^2.0.0",
+    "turtle-validator": "^1.0.2"
   }
 }

--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -71,6 +71,10 @@ vf:DistributionAgreement  a       owl:Class ;
         rdfs:subClassOf   vf:Agreement ;
         rdfs:comment      "An agreement to distribute some resource in exchange for inputs or outputs created by other agents." .
 
+vf:ExchangeRate a owl:Class ;
+        rdfs:label        "vf:ExchangeAgreement" ;
+        rdfs:comment      "Used with exchange agreements to represante an exchange rate between two reciprocal flows" .
+
 # OBSERVATION CLASSES
 
 
@@ -259,6 +263,30 @@ vf:under  a          owl:ObjectProperty ;
         rdfs:label   "under" ;
         rdfs:range   vf:Agreement ;
         rdfs:comment        "Reference an agreement between agents which specifies the rules or policies which govern this event." .
+
+vf:numeratorFlow a   owl:ObjectProperty ;
+        rdfs:label   "vf:numeratorFlow" ;
+        rdfs:domain  vf:ExchangeRate ;
+        rdfs:range   [ owl:unionOf (vf:EconomicEvent vf:Commitment vf:Intent ) ] ;
+        rdfs:comment "References flow related to the numerator value" .
+
+vf:denominatorFlow a   owl:ObjectProperty ;
+        rdfs:label   "vf:denominatorFlow" ;
+        rdfs:domain  vf:ExchangeRate ;
+        rdfs:range   [ owl:unionOf (vf:EconomicEvent vf:Commitment vf:Intent ) ] ;
+        rdfs:comment "References flow related to the denominator value" .
+
+vf:numerator a   owl:DataProperty ;
+        rdfs:label   "vf:numerator" ;
+        rdfs:domain  vf:ExchangeRate ;
+        rdfs:range  xsd:decimal ;
+        rdfs:comment "Numerator value" .
+
+vf:denominator a   owl:DataProperty ;
+        rdfs:label   "vf:denominator" ;
+        rdfs:domain  vf:ExchangeRate ;
+        rdfs:range  xsd:decimal ;
+        rdfs:comment "Denominator value" .
 
 vf:createdBy  a        owl:ObjectProperty ;
         rdfs:label   "created by" ;


### PR DESCRIPTION
This PR proposes `vf:ExchangeRate` which allows referencing two flows together with values to calculate exchange rate. Both units come from flows. For example:

```yaml
`@context': ...
`@graph`:

  - `@id`: ex:an-agreement
    `@type`: Agreement

  - `@id`: ex:work-event
    `@type`: EconomicEvent
    under: ex:an-agreement
    action: work
    quantity:
      'qudt:numericValue': 3
      `qudt:unit`: unit:Hour

  - `@id`: ex:use-event
    `@type`: EconomicEvent
    under: ex:an-agreement
    action: use
    affects: ex:some-tool
    quantity:
      'qudt:numericValue': 2
      `qudt:unit`: unit:Hour

  - `@id`: ex:issue-event
    `@type`: EconomicEvent
    under: ex:an-agreement
    action: issue
    affectedClassifiedAs: http://www.wikidata.org/entity/Q618355 # apple juice
    quantity:
      'qudt:numericValue': 20
      `qudt:unit`: unit:Liter 

  - `@id`: ex:an-exchange-rate
    `@type`: ExchangeRate
    under: ex:an-agreement
    numerator: 5
    denominator: 1
    numeratorFlow: ex:issue-event
    denominatorFlow: ex:work-event

  - `@id`: ex:another-exchange-rate
    `@type`: ExchangeRate
    under: ex:an-agreement
    numerator: 2.5
    denominator: 1
    numeratorFlow: ex:issue-event
    denominatorFlow: ex:use-event
```

One can use them with `vf:Commitment` in the same way. I'll try to add an example of a *Proposal* which uses exchange rate together with two intents.