### PR TITLE
initial examples for shared use of independently controlled studios

### DIFF
--- a/examples/shared-studios-usage.yaml
+++ b/examples/shared-studios-usage.yaml
@@ -2,16 +2,11 @@
 # https://github.com/valueflows/valueflows/wiki/Use-Cases-and-Requirements#independent-shared-therapy-studios
 
 '@context':
-  '@vocab': https://w3id.org/valueflows#
-  xsd: http://www.w3.org/2001/XMLSchema#
-  time: http://www.w3.org/2006/time#
-  time:inXSDDateTimeStamp:
-    '@type': xsd:dateTimeStamp
-  alice: https://alice.example/
-  bob: https://bob.example/
-  claudia: https://claudia.example/
-  daniel: https://daniel.example/
-  erica: https://erica.example/
+  - https://git.io/vf-examples-jsonld-context
+  - alice: https://alice.example/
+    bob: https://bob.example/
+    claudia: https://claudia.example/
+    daniel: https://daniel.example/
 
 '@graph':
 
@@ -39,40 +34,34 @@
 
   - '@id': alice:e5afaa28-1080-4912-835b-46883efb83e6
     '@type': Commitment
-    provider: alice
-    receiver: alice
+    provider: https://alice.example/
+    receiver: https://alice.example/
     action: use
     involves: alice:9120abe7-ebe3-4bfb-8ad4-60aa585a04bd
     commitedQuantity:
-      qudt:unit: unit:Unitless
+      qudt:unit: unit:Number
       qudt:numericValue: 1
     committedTime:
-      '@type': time:ProperInterval
       time:intervalStarts:
-        '@type': time:Instant
         time:inXSDDateTimeStamp: 2010-10-14T12:00:00-5:00
-      'time:intervalEnds':
-        '@type': time:Instant
+      time:intervalEnds:
         time:inXSDDateTimeStamp: 2018-10-14T16:00:00-5:00
     
 # Often Alice agrees that Daniel, Erica (or one of 7 other people) can use the studio she controls on specific times.
 
   - '@id': alice:848618bd-fdd7-43d8-8d05-1a33128372d1
     '@type': Commitment
-    provider: alice
-    receiver: daniel
+    provider: https://alice.example/
+    receiver: https://daniel.example/
     action: use
     involves: alice:9120abe7-ebe3-4bfb-8ad4-60aa585a04bd
     commitedQuantity:
-      qudt:unit: unit:Unitless
+      qudt:unit: unit:Number
       qudt:numericValue: 1
     committedTime:
-      '@type': time:ProperInterval
       time:intervalStarts:
-        '@type': time:Instant
         time:inXSDDateTimeStamp: 2010-10-14T16:00:00-5:00
-      'time:intervalEnds':
-        '@type': time:Instant
+      time:intervalEnds:
         time:inXSDDateTimeStamp: 2018-10-14T20:00:00-5:00
     
 # Sometimes Alice has to agree with Bob or Claudia that she will use one of the studios they control on specific time.
@@ -80,19 +69,16 @@
 
   - '@id': bob:838379a1-8b21-49bf-ba49-6de013c722d0
     '@type': Commitment
-    provider: bob
-    receiver: alice
+    provider: https://bob.example/
+    receiver: https://alice.example/
     action: use
     involves: bob:dbc325de-5446-4789-869d-7b0353b05136
     commitedQuantity:
-      qudt:unit: unit:Unitless
+      qudt:unit: unit:Number
       qudt:numericValue: 1
     committedTime:
-      '@type': time:ProperInterval
       time:intervalStarts:
-        '@type': time:Instant
         time:inXSDDateTimeStamp: 2010-10-14T17:00:00-5:00
-      'time:intervalEnds':
-        '@type': time:Instant
+      time:intervalEnds:
         time:inXSDDateTimeStamp: 2018-10-14T20:00:00-5:00
-    
+ 

--- a/examples/shared-studios-usage.yaml
+++ b/examples/shared-studios-usage.yaml
@@ -1,0 +1,98 @@
+# Independent, shared therapy studios
+# https://github.com/valueflows/valueflows/wiki/Use-Cases-and-Requirements#independent-shared-therapy-studios
+
+'@context':
+  '@vocab': https://w3id.org/valueflows#
+  xsd: http://www.w3.org/2001/XMLSchema#
+  time: http://www.w3.org/2006/time#
+  time:inXSDDateTimeStamp:
+    '@type': xsd:dateTimeStamp
+  alice: https://alice.example/
+  bob: https://bob.example/
+  claudia: https://claudia.example/
+  daniel: https://daniel.example/
+  erica: https://erica.example/
+
+'@graph':
+
+  # resources 3 studios
+
+  - '@id': alice:9120abe7-ebe3-4bfb-8ad4-60aa585a04bd
+    '@type': EconomicResource
+    trackingIdentifier: urn:uuid:3b5610d2-5789-4981-861d-cf37b166306f
+    skos:note: studio controled by Alice
+    classifiedAs: http://www.wikidata.org/entity/Q746628 # studio
+
+  - '@id': bob:dbc325de-5446-4789-869d-7b0353b05136
+    '@type': EconomicResource
+    trackingIdentifier: urn:uuid:9e81985d-000b-4b8e-b02f-695257ecf2a2
+    skos:note: studio controled by Bob
+    classifiedAs: http://www.wikidata.org/entity/Q746628 # studio
+
+  - '@id': claudia:9259a983-2d8b-40bc-8fb6-883818eb1264
+    '@type': EconomicResource
+    trackingIdentifier: urn:uuid:dcbc94b8-5346-4bea-931d-38026f53f2b8
+    skos:note: studio controled by Claudia
+    classifiedAs: http://www.wikidata.org/entity/Q746628 # studio
+
+# Alice uses studio she controls whenever she needs.
+
+  - '@id': alice:e5afaa28-1080-4912-835b-46883efb83e6
+    '@type': Commitment
+    provider: alice
+    receiver: alice
+    action: use
+    involves: alice:9120abe7-ebe3-4bfb-8ad4-60aa585a04bd
+    commitedQuantity:
+      qudt:unit: unit:Unitless
+      qudt:numericValue: 1
+    committedTime:
+      '@type': time:ProperInterval
+      time:intervalStarts:
+        '@type': time:Instant
+        time:inXSDDateTimeStamp: 2010-10-14T12:00:00-5:00
+      'time:intervalEnds':
+        '@type': time:Instant
+        time:inXSDDateTimeStamp: 2018-10-14T16:00:00-5:00
+    
+# Often Alice agrees that Daniel, Erica (or one of 7 other people) can use the studio she controls on specific times.
+
+  - '@id': alice:848618bd-fdd7-43d8-8d05-1a33128372d1
+    '@type': Commitment
+    provider: alice
+    receiver: daniel
+    action: use
+    involves: alice:9120abe7-ebe3-4bfb-8ad4-60aa585a04bd
+    commitedQuantity:
+      qudt:unit: unit:Unitless
+      qudt:numericValue: 1
+    committedTime:
+      '@type': time:ProperInterval
+      time:intervalStarts:
+        '@type': time:Instant
+        time:inXSDDateTimeStamp: 2010-10-14T16:00:00-5:00
+      'time:intervalEnds':
+        '@type': time:Instant
+        time:inXSDDateTimeStamp: 2018-10-14T20:00:00-5:00
+    
+# Sometimes Alice has to agree with Bob or Claudia that she will use one of the studios they control on specific time.
+# For example when she already agreed that someone else will use studio that she controls at that specific time.
+
+  - '@id': bob:838379a1-8b21-49bf-ba49-6de013c722d0
+    '@type': Commitment
+    provider: bob
+    receiver: alice
+    action: use
+    involves: bob:dbc325de-5446-4789-869d-7b0353b05136
+    commitedQuantity:
+      qudt:unit: unit:Unitless
+      qudt:numericValue: 1
+    committedTime:
+      '@type': time:ProperInterval
+      time:intervalStarts:
+        '@type': time:Instant
+        time:inXSDDateTimeStamp: 2010-10-14T17:00:00-5:00
+      'time:intervalEnds':
+        '@type': time:Instant
+        time:inXSDDateTimeStamp: 2018-10-14T20:00:00-5:00
+    


### PR DESCRIPTION
Based on https://github.com/valueflows/valueflows/wiki/Use-Cases-and-Requirements#independent-shared-therapy-studios

Making commitment to oneself serves purpose of reserving the time and not making conflicting commitment to someone else.

I plan to add another variants where agents can exchange commitments. So when Alice makes commitment to Daniel for use of Alice's studio and then she gets commitment from Bob for use of his studio. Possibly she could exchange those commitments with Daniel and use the studio she controls while Daniel gets to use studio that Bob controls. 