### PR TITLE
New relationships between exchange agreement and commitments/events.

### DIFF
--- a/examples/exch-agreement.yaml
+++ b/examples/exch-agreement.yaml
@@ -13,7 +13,7 @@
   # Exchange agreement with commitments
 
   - '@id': alice:57f1c1d0-432e-4bfa-9d32-002b8955a708
-    '@type': ExchangeAgreement
+    '@type': Agreement
     skos:note: Alice commits to giving Bob 50 kg of apples in exchange for 10 liters of apple cider.
 
   - '@id': alice:2342d456-5d6f-46d5-a7ed-3ac7bfd5a86c
@@ -23,7 +23,7 @@
     provider: https://alice.example/
     receiver: https://bob.example/
     resourceClassifiedAs: https://www.wikidata.org/wiki/Q89 # apples
-    affectedQuantity:
+    quantifiedAs:
       qudt:unit: unit: Kilogram
       qudt:numericValue: 50
 
@@ -34,25 +34,35 @@
     provider: https://bob.example/
     receiver: https://alice.example/
     resourceClassifiedAs: https://www.wikidata.org/wiki/Q5977438 # soft apple cider
-    affectedQuantity:
+    quantifiedAs:
       qudt:unit: unit: Liter
       qudt:numericValue: 10
 
   # Exchange without commitments
 
   - '@id': store:ac9ec98d-db80-44dc-97be-7aa149b2fe5d
-    '@type': ExchangeAgreement
+    '@type': Agreement
     skos:note: Carol purchased a new bucket at the hardware store and paid 5 dollars for it.
 
   - '@id': store:a8356625-bf64-4c16-9099-28aa1b718c4b
     '@type': EconomicEvent
-    clauseOf: store:ac9ec98d-db80-44dc-97be-7aa149b2fe5d
+    realizationOf: store:ac9ec98d-db80-44dc-97be-7aa149b2fe5d
     action: give
-    provider: https://alice.example/
-    receiver: https://bob.example/
-    resourceClassifiedAs: https://www.wikidata.org/wiki/Q89 # apples
-    affectedQuantity:
-      qudt:unit: unit: Kilogram
-      qudt:numericValue: 50
+    provider: https://store.example/
+    receiver: https://carol.example/
+    resourceClassifiedAs: https://www.wikidata.org/wiki/Q47107 # bucket
+    quantifiedAs:
+      qudt:unit: unit: Number
+      qudt:numericValue: 1
 
-  
+  - '@id': store:a8356625-bf64-4c16-9099-28aa1b718c4b
+    '@type': EconomicEvent
+    realizationOf: store:ac9ec98d-db80-44dc-97be-7aa149b2fe5d
+    action: give
+    provider: https://carol.example/
+    receiver: https://store.example/
+    resourceClassifiedAs: https://www.wikidata.org/wiki/Q4917 # US dollar
+    resourceInventoriedAs: carol:e56fd654-7b94-4d96-8e60-de39e08329a7 # Carol's bank account
+    quantifiedAs:
+      qudt:unit: unit: Number
+      qudt:numericValue: 5

--- a/examples/exch-agreement.yaml
+++ b/examples/exch-agreement.yaml
@@ -1,0 +1,58 @@
+# Example: Simple exchange agreements
+
+'@context':
+  - https://git.io/vf-examples-jsonld-context
+  - alice: https://alice.example/
+    bob: https://bob.example/
+    carol: https://carol.example/
+    store: https://store.example/
+
+'@id': rgh:valueflows/valueflows/master/examples/exch-agreement.yaml
+'@graph':
+
+  # Exchange agreement with commitments
+
+  - '@id': alice:57f1c1d0-432e-4bfa-9d32-002b8955a708
+    '@type': ExchangeAgreement
+    skos:note: Alice commits to giving Bob 50 kg of apples in exchange for 10 liters of apple cider.
+
+  - '@id': alice:2342d456-5d6f-46d5-a7ed-3ac7bfd5a86c
+    '@type': Commitment
+    clauseOf: alice:57f1c1d0-432e-4bfa-9d32-002b8955a708
+    action: give
+    provider: https://alice.example/
+    receiver: https://bob.example/
+    resourceClassifiedAs: https://www.wikidata.org/wiki/Q89 # apples
+    affectedQuantity:
+      qudt:unit: unit: Kilogram
+      qudt:numericValue: 50
+
+  - '@id': bob:fd399b37-0740-4a68-a184-1e655021ca21
+    '@type': Commitment
+    clauseOf: alice:57f1c1d0-432e-4bfa-9d32-002b8955a708
+    action: give
+    provider: https://bob.example/
+    receiver: https://alice.example/
+    resourceClassifiedAs: https://www.wikidata.org/wiki/Q5977438 # soft apple cider
+    affectedQuantity:
+      qudt:unit: unit: Liter
+      qudt:numericValue: 10
+
+  # Exchange without commitments
+
+  - '@id': store:ac9ec98d-db80-44dc-97be-7aa149b2fe5d
+    '@type': ExchangeAgreement
+    skos:note: Carol purchased a new bucket at the hardware store and paid 5 dollars for it.
+
+  - '@id': store:a8356625-bf64-4c16-9099-28aa1b718c4b
+    '@type': EconomicEvent
+    clauseOf: store:ac9ec98d-db80-44dc-97be-7aa149b2fe5d
+    action: give
+    provider: https://alice.example/
+    receiver: https://bob.example/
+    resourceClassifiedAs: https://www.wikidata.org/wiki/Q89 # apples
+    affectedQuantity:
+      qudt:unit: unit: Kilogram
+      qudt:numericValue: 50
+
+  

--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -541,19 +541,19 @@ vf:resourceConformsTo
         vs:term_status      "unstable" ;
         rdfs:comment        "The primary resource knowledge specification or definition of an existing or potential resource." .
 
-vf:includesCommitments a    owl:ObjectProperty ;
-        rdfs:label          "includes commitments" ;
-        rdfs:domain         vf:ExchangeAgreement ;
-        rdfs:range          vf:Commitment ;
+vf:clauseOf a               owl:ObjectProperty ;
+        rdfs:label          "clause of" ;
+        rdfs:domain         vf:Commitment ;
+        rdfs:range          vf:ExchangeAgreement ;
         vs:term_status      "unstable" ;
-        rdfs:comment        "The specific commitments that are part of this exchange agreement." .
+        rdfs:comment        "This commitment is part of the exchange agreement, which could not exist without it." .
 
-vf:includesEvents a         owl:ObjectProperty ;
-        rdfs:label          "includes events" ;
-        rdfs:domain         vf:ExchangeAgreement ;
-        rdfs:range          vf:EconomicEvent ;
+vf:realizationOf a           owl:ObjectProperty ;
+        rdfs:label          "realization of" ;
+        rdfs:domain         vf:EconomicEvent ;
+        rdfs:range          vf:ExchangeAgreement ;
         vs:term_status      "unstable" ;
-        rdfs:comment        "The actual economic events that occur related to this exchange agreement." .
+        rdfs:comment        "This economic event occurs as part of this exchange." .
 
 # ################################ agent relationship verbs
 

--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -75,17 +75,17 @@ vf:Agreement  a             owl:Class ;
         vs:term_status      "unstable" ;
         rdfs:comment        "Any type of agreement among economic agents, that can be referenced in VF to clarify the economic activity.  This is a placeholder pending investigating other vocabularies." .
 
-vf:ExchangeAgreement  a     owl:Class ;
-        rdfs:label          "vf:ExchangeAgreement" ;
-        rdfs:subClassOf     vf:Agreement ;
-        vs:term_status      "unstable" ;
-        rdfs:comment        "An agreement to exchange something with another agent(s), covering one set of reciprocal commitments and/or economic events." .
+#vf:ExchangeAgreement  a     owl:Class ;
+#        rdfs:label          "vf:ExchangeAgreement" ;
+#        rdfs:subClassOf     vf:Agreement ;
+#       vs:term_status      "unstable" ;
+#        rdfs:comment        "An agreement to exchange something with another agent(s), covering one set of reciprocal commitments and/or economic events." .
 
-vf:DistributionAgreement  a  owl:Class ;
-        rdfs:label           "vf:DistributionAgreement" ;
-        rdfs:subClassOf      vf:Agreement ;
-        vs:term_status      "unstable" ;
-        rdfs:comment         "An agreement to distribute some resource in exchange for inputs or outputs created by other agents." .
+#vf:DistributionAgreement  a  owl:Class ;
+#        rdfs:label           "vf:DistributionAgreement" ;
+#        rdfs:subClassOf      vf:Agreement ;
+#        vs:term_status      "unstable" ;
+#        rdfs:comment         "An agreement to distribute some resource in exchange for inputs or outputs created by other agents." .
 
 # OBSERVATION CLASSES
 
@@ -544,14 +544,14 @@ vf:resourceConformsTo
 vf:clauseOf a               owl:ObjectProperty ;
         rdfs:label          "clause of" ;
         rdfs:domain         vf:Commitment ;
-        rdfs:range          vf:ExchangeAgreement ;
+        rdfs:range          vf:Agreement ;
         vs:term_status      "unstable" ;
-        rdfs:comment        "This commitment is part of the exchange agreement, which could not exist without it." .
+        rdfs:comment        "This commitment is part of the agreement, which could not exist without it." .
 
 vf:realizationOf a           owl:ObjectProperty ;
         rdfs:label          "realization of" ;
         rdfs:domain         vf:EconomicEvent ;
-        rdfs:range          vf:ExchangeAgreement ;
+        rdfs:range          vf:Agreement ;
         vs:term_status      "unstable" ;
         rdfs:comment        "This economic event occurs as part of this exchange." .
 

--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -73,19 +73,7 @@ vf:Satisfaction  a          owl:Class ;
 vf:Agreement  a             owl:Class ;
         rdfs:label          "vf:Agreement" ;
         vs:term_status      "unstable" ;
-        rdfs:comment        "Any type of agreement among economic agents, that can be referenced in VF to clarify the economic activity.  This is a placeholder pending investigating other vocabularies." .
-
-#vf:ExchangeAgreement  a     owl:Class ;
-#        rdfs:label          "vf:ExchangeAgreement" ;
-#        rdfs:subClassOf     vf:Agreement ;
-#       vs:term_status      "unstable" ;
-#        rdfs:comment        "An agreement to exchange something with another agent(s), covering one set of reciprocal commitments and/or economic events." .
-
-#vf:DistributionAgreement  a  owl:Class ;
-#        rdfs:label           "vf:DistributionAgreement" ;
-#        rdfs:subClassOf      vf:Agreement ;
-#        vs:term_status      "unstable" ;
-#        rdfs:comment         "An agreement to distribute some resource in exchange for inputs or outputs created by other agents." .
+        rdfs:comment        "Any type of agreement among economic agents." .
 
 # OBSERVATION CLASSES
 

--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -79,7 +79,7 @@ vf:ExchangeAgreement  a     owl:Class ;
         rdfs:label          "vf:ExchangeAgreement" ;
         rdfs:subClassOf     vf:Agreement ;
         vs:term_status      "unstable" ;
-        rdfs:comment        "An agreement to exchange something with another agent(s), containing commitments towards that end." .
+        rdfs:comment        "An agreement to exchange something with another agent(s), covering one set of reciprocal commitments and/or economic events." .
 
 vf:DistributionAgreement  a  owl:Class ;
         rdfs:label           "vf:DistributionAgreement" ;
@@ -541,7 +541,19 @@ vf:resourceConformsTo
         vs:term_status      "unstable" ;
         rdfs:comment        "The primary resource knowledge specification or definition of an existing or potential resource." .
 
+vf:includesCommitments a    owl:ObjectProperty ;
+        rdfs:label          "includes commitments" ;
+        rdfs:domain         vf:ExchangeAgreement ;
+        rdfs:range          vf:Commitment ;
+        vs:term_status      "unstable" ;
+        rdfs:comment        "The specific commitments that are part of this exchange agreement." .
 
+vf:includesEvents a         owl:ObjectProperty ;
+        rdfs:label          "includes events" ;
+        rdfs:domain         vf:ExchangeAgreement ;
+        rdfs:range          vf:EconomicEvent ;
+        vs:term_status      "unstable" ;
+        rdfs:comment        "The actual economic events that occur related to this exchange agreement." .
 
 # ################################ agent relationship verbs
 


### PR DESCRIPTION
Other direction than vf:under.  Exchange contains commitments and/or events.  Naming needs some work.  Also still thinking about separating reciprocal ones, but we can look at that later when we do proposals if there is no immediate agreement.