### PR TITLE
improve integration with OWL-Time

### DIFF
--- a/docs/specification/external-terms.md
+++ b/docs/specification/external-terms.md
@@ -44,8 +44,6 @@ https://www.w3.org/TR/owl-time
 * [`time:before`](https://www.w3.org/TR/owl-time/#time:before)
 * [`time:after`](https://www.w3.org/TR/owl-time/#time:after)
 * [`time:intervalDuring`](https://www.w3.org/TR/owl-time/#time:intervalDuring)
-* [`time:intervalStarts'](https://www.w3.org/TR/owl-time/#time:intervalStarts)
-* [`time:intervalFinishes'](https://www.w3.org/TR/owl-time/#time:intervalFinishes)
 
 `vf` defines two property chain axioms `vf:hasBeginning` and `vf:hasEnd` as slight variant
 of [Alignment of PROV-O with OWL-Time(https://www.w3.org/TR/owl-time/#time-prov)]

--- a/docs/specification/external-terms.md
+++ b/docs/specification/external-terms.md
@@ -20,3 +20,32 @@ http://xmlns.com/foaf/spec/
 https://www.w3.org/TR/vocab-org/
 
 * [`org:Organization`](https://www.w3.org/TR/vocab-org/#org:Organization)
+
+## QUDT
+
+http://qudt.org/doc/2016/DOC_SCHEMA-QUDT-v2.0.html
+
+* [`qudt:QuantityValue`](http://qudt.org/doc/2016/DOC_SCHEMA-QUDT-v2.0.html#Classes)
+* [`qudt:unit`](http://qudt.org/doc/2016/DOC_SCHEMA-QUDT-v2.0.html#Properties)
+* [`qudt:numericValue`](http://qudt.org/doc/2016/DOC_SCHEMA-QUDT-v2.0.html#Properties)
+
+### UNIT
+
+http://qudt.org/doc/2017/DOC_VOCAB-UNITS-BASE.html
+
+* [`unit:Number`](http://qudt.org/doc/2017/DOC_VOCAB-UNITS-BASE.html#Instances)
+
+## TIME
+
+https://www.w3.org/TR/owl-time
+
+* [`time:inXSDDateTimeStamp`](https://www.w3.org/TR/owl-time/#time:inXSDDateTimeStamp)
+* [`time:hasDuration`](https://www.w3.org/TR/owl-time/#time:hasDuration)
+* [`time:before`](https://www.w3.org/TR/owl-time/#time:before)
+* [`time:after`](https://www.w3.org/TR/owl-time/#time:after)
+* [`time:intervalDuring`](https://www.w3.org/TR/owl-time/#time:intervalDuring)
+* [`time:intervalStarts'](https://www.w3.org/TR/owl-time/#time:intervalStarts)
+* [`time:intervalFinishes'](https://www.w3.org/TR/owl-time/#time:intervalFinishes)
+
+`vf` defines two property chain axioms `vf:hasBeginning` and `vf:hasEnd` as slight variant
+of [Alignment of PROV-O with OWL-Time(https://www.w3.org/TR/owl-time/#time-prov)]

--- a/examples/fulfill-satisfy.yaml
+++ b/examples/fulfill-satisfy.yaml
@@ -68,14 +68,8 @@
     affectedQuantity:
       qudt:unit: unit:Hour
       qudt:numericValue: 4
-    observedTime:
-      '@type': time:ProperInterval
-      time:intervalStarts:
-        '@type': time:Instant
-        time:inXSDDateTimeStamp: 2018-10-14T8:00:00-0:00
-      time:intervalEnds:
-        '@type': time:Instant
-        time:inXSDDateTimeStamp: 2018-10-14T12:00:00-0:00
+    hasStart: 2018-10-14T8:00:00-0:00
+    hasEnd: 2018-10-14T12:00:00-0:00
 
   - '@id': mfg:6f438393-7f87-4914-806c-e23a4fd15e89
     '@type': Fulfillment
@@ -94,14 +88,8 @@
     affectedQuantity:
       qudt:unit: unit:Hour
       qudt:numericValue: 4
-    observedTime:
-      '@type': time:ProperInterval
-      time:intervalStarts:
-        '@type': time:Instant
-        time:inXSDDateTimeStamp: 2018-10-14T13:00:00-0:00
-      time:intervalEnds:
-        '@type': time:Instant
-        time:inXSDDateTimeStamp: 2018-10-14T17:00:00-0:00
+    hasStart: 2018-10-14T13:00:00-0:00
+    hasEnd: 2018-10-14T17:00:00-0:00
 
   - '@id': mfg:0f563083-8da4-46fe-adc3-68b05ba06320
     '@type': Fulfillment

--- a/examples/fulfill-satisfy.yaml
+++ b/examples/fulfill-satisfy.yaml
@@ -68,7 +68,7 @@
     affectedQuantity:
       qudt:unit: unit:Hour
       qudt:numericValue: 4
-    hasStart: 2018-10-14T8:00:00-0:00
+    hasBeginning: 2018-10-14T8:00:00-0:00
     hasEnd: 2018-10-14T12:00:00-0:00
 
   - '@id': mfg:6f438393-7f87-4914-806c-e23a4fd15e89
@@ -88,7 +88,7 @@
     affectedQuantity:
       qudt:unit: unit:Hour
       qudt:numericValue: 4
-    hasStart: 2018-10-14T13:00:00-0:00
+    hasBeginning: 2018-10-14T13:00:00-0:00
     hasEnd: 2018-10-14T17:00:00-0:00
 
   - '@id': mfg:0f563083-8da4-46fe-adc3-68b05ba06320

--- a/examples/process-workflow.yaml
+++ b/examples/process-workflow.yaml
@@ -49,6 +49,7 @@
 
   # Economic resource after
 
+  - '@id': alice:e1721a61-cd47-4556-84b9-8b1b81da15bf
     '@type': EconomicResource
     resourceConformsTo: http://opensourceecology.org/wiki/Wikispeed_SGT01 # car
     trackingIdentifier: JHMCD38698S061469

--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -46,7 +46,6 @@ vf:RecipeProcess a          owl:Class ;
 
 vf:RecipeFlow a             owl:Class ;
         rdfs:label          "vf:RecipeFlow" ;
-        rdfs:subClassOf     time:TemporalEntity ;
         vs:term_status      "unstable" ;
         rdfs:comment        "The linkage between a process recipe, an action that structures a recipe, and a resource specification." .
 
@@ -55,13 +54,11 @@ vf:RecipeFlow a             owl:Class ;
 
 vf:Intent  a                owl:Class ;
         rdfs:label          "vf:Intent" ;
-        rdfs:subClassOf     time:TemporalEntity ;
         vs:term_status      "unstable" ;
         rdfs:comment        "A planned economic flow, which can lead to economic events (sometimes through commitments)" .
 
 vf:Commitment  a            owl:Class ;
         rdfs:label          "vf:Commitment" ;
-        rdfs:subClassOf     time:TemporalEntity ;
         vs:term_status      "testing" ;
         rdfs:comment        "A planned economic flow that has been promised by an agent to another agent." .
 
@@ -97,7 +94,6 @@ vf:EconomicResource  a      owl:Class ;
 
 vf:Process  a               owl:Class ;
         rdfs:label          "vf:Process" ;
-        rdfs:subClassOf     time:TemporalEntity ;
         vs:term_status      "testing" ;
         rdfs:comment        "An activity that changes inputs into outputs.  It could transform or transport economic resource(s)." .
 
@@ -108,7 +104,6 @@ vf:Transfer  a              owl:Class ;
 
 vf:EconomicEvent  a         owl:Class ;
         rdfs:label          "vf:EconomicEvent" ;
-        rdfs:subClassOf     time:TemporalEntity ;
         vs:term_status      "testing" ;
         rdfs:comment        "An observed economic flow, as opposed to a flow planned to happen in the future. This could reflect a change in the quantity of an economic resource. It is also defined by its behavior in relation to the economic resource (see vf:action)" .
 
@@ -286,13 +281,13 @@ vf:hasBeginning a           owl:DatatypeProperty ;
         rdfs:domain         time:TemporalEntity ;
         rdfs:range          xsd:dateTimeStamp ;
         owl:propertyChainAxiom (time:hasBeginning time:inXSDDateTimeStamp) ;
-        rdfs:comment        "Specific time marking the beginning of the flow".
+        rdfs:comment        "Specific time marking the exact beginning of flow or process".
 
 vf:hasEnd a                 owl:DatatypeProperty ;
         rdfs:domain         time:TemporalEntity ;
         rdfs:range          xsd:dateTimeStamp ;
         owl:propertyChainAxiom (time:hasEnd time:inXSDDateTimeStamp) ;
-        rdfs:comment        "Specific time marking the end of the flow".
+        rdfs:comment        "Specific time marking the exact end of flow or process".
 
 vf:currentQuantity a        owl:ObjectProperty ;
         rdfs:label          "current quantity" ;

--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -275,12 +275,24 @@ vf:under  a                 owl:ObjectProperty ;
 #        vs:term_status      "unstable" ;
 #        rdfs:comment        "References the commitment that was fully or partially created because of the economic event, often based on a prior agreement." .
 
-vf:contains  a              owl:ObjectProperty ;
+vf:contains a               owl:ObjectProperty ;
         rdfs:label          "contains" ;
         rdfs:domain         vf:EconomicResource ;
         rdfs:range          vf:EconomicResource ;
         vs:term_status      "unstable" ;
         rdfs:comment        "Used when a stock economic resource contains units also defined as economic resources." .
+
+vf:hasBeginning a           owl:DatatypeProperty ;
+        rdfs:domain         time:TemporalEntity ;
+        rdfs:range          xsd:dateTimeStamp ;
+        owl:propertyChainAxiom (time:hasBeginning time:inXSDDateTimeStamp) ;
+        rdfs:comment        "Specific time marking the beginning of the flow".
+
+vf:hasEnd a                 owl:DatatypeProperty ;
+        rdfs:domain         time:TemporalEntity ;
+        rdfs:range          xsd:dateTimeStamp ;
+        owl:propertyChainAxiom (time:hasEnd time:inXSDDateTimeStamp) ;
+        rdfs:comment        "Specific time marking the end of the flow".
 
 vf:currentQuantity a        owl:ObjectProperty ;
         rdfs:label          "current quantity" ;

--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -46,6 +46,7 @@ vf:RecipeProcess a          owl:Class ;
 
 vf:RecipeFlow a             owl:Class ;
         rdfs:label          "vf:RecipeFlow" ;
+        rdfs:subClassOf     time:TemporalEntity ;
         vs:term_status      "unstable" ;
         rdfs:comment        "The linkage between a process recipe, an action that structures a recipe, and a resource specification." .
 
@@ -54,11 +55,13 @@ vf:RecipeFlow a             owl:Class ;
 
 vf:Intent  a                owl:Class ;
         rdfs:label          "vf:Intent" ;
+        rdfs:subClassOf     time:TemporalEntity ;
         vs:term_status      "unstable" ;
         rdfs:comment        "A planned economic flow, which can lead to economic events (sometimes through commitments)" .
 
 vf:Commitment  a            owl:Class ;
         rdfs:label          "vf:Commitment" ;
+        rdfs:subClassOf     time:TemporalEntity ;
         vs:term_status      "testing" ;
         rdfs:comment        "A planned economic flow that has been promised by an agent to another agent." .
 
@@ -94,6 +97,7 @@ vf:EconomicResource  a      owl:Class ;
 
 vf:Process  a               owl:Class ;
         rdfs:label          "vf:Process" ;
+        rdfs:subClassOf     time:TemporalEntity ;
         vs:term_status      "testing" ;
         rdfs:comment        "An activity that changes inputs into outputs.  It could transform or transport economic resource(s)." .
 
@@ -104,6 +108,7 @@ vf:Transfer  a              owl:Class ;
 
 vf:EconomicEvent  a         owl:Class ;
         rdfs:label          "vf:EconomicEvent" ;
+        rdfs:subClassOf     time:TemporalEntity ;
         vs:term_status      "testing" ;
         rdfs:comment        "An observed economic flow, as opposed to a flow planned to happen in the future. This could reflect a change in the quantity of an economic resource. It is also defined by its behavior in relation to the economic resource (see vf:action)" .
 
@@ -346,34 +351,6 @@ vf:primaryLocation a        owl:ObjectProperty ;
         #rdfs:range          vf:Location ;
         vs:term_status      "unstable" ;
         rdfs:comment        "The main place an agent is located, often an address where activities occur and mail can be sent. This is usually a mappable geographic location.  It also could be a website address, as in the case of agents who have no physical location." .
-
-vf:observedTime a           owl:ObjectProperty ;
-        rdfs:label          "observed time" ;
-        rdfs:domain         vf:EconomicEvent ;
-        rdfs:range          time:TemporalEntity ;
-        vs:term_status      "unstable" ;
-        rdfs:comment        "The actual temporal instant or interval." .
-
-vf:committedTime a          owl:ObjectProperty ;
-        rdfs:label          "committed time" ;
-        rdfs:domain         vf:Commitment ;
-        rdfs:range          time:TemporalEntity ;
-        vs:term_status      "unstable" ;
-        rdfs:comment        "The promised temporal instant or interval." .
-
-vf:intendedTime a           owl:ObjectProperty ;
-        rdfs:label          "intended time" ;
-        rdfs:domain         vf:Intent ;
-        rdfs:range          time:TemporalEntity ;
-        vs:term_status      "unstable" ;
-        rdfs:comment        "The intended temporal instant or interval." .
-
-vf:plannedTime a            owl:ObjectProperty ;
-        rdfs:label          "planned time" ;
-        rdfs:domain         vf:Process ;
-        rdfs:range          time:TemporalEntity ;
-        vs:term_status      "unstable" ;
-        rdfs:comment        "The planned or estimated calendar time the process will take (whether being actually worked or not)." .
 
 vf:image a                  owl:DatatypeProperty ;
         vs:term_status      "unstable" ;


### PR DESCRIPTION
This reduces one level of indirection and duplication in the vocab. We can simply consider any `Intent`, `Commitment` and `EconomicEvent` as more specific `time:TemporalEntity` and use properties defined in [Time Ontology in OWL](https://www.w3.org/TR/owl-time/#namespaces) directly one them. Since we already have distinct `Intent`, `Commitment` and `EconomicEvent` we don't need in addition `observed*`, `commited*` and `intended*` prefixes. One can simply check `rdf:type` (`@type`) of flow to have that knowledge.

Our examples already incorrectly use `time:intervalEnds` and `time:intervalStarts` (which have `time:ProperInterval` as range) we have to update them to `time:hasBeggining` and `time:hasEnd` (which have `time:Instant` as range). If we accept this PR, we can use those properties directly on any flow or Process.