### PR TITLE
Core attributes (was: affects > involves, affectedQuantity > observedQuantity)

### DIFF
--- a/examples/fulfill-satisfy.yaml
+++ b/examples/fulfill-satisfy.yaml
@@ -65,7 +65,7 @@
     provider: https://bob.example/
     receiver: https://manufacturing.example/
     resourceClassifiedAs: https://www.wikidata.org/wiki/Q192047 # machining
-    affectedQuantity:
+    observedQuantity:
       qudt:unit: unit:Hour
       qudt:numericValue: 4
     observedTime:
@@ -91,7 +91,7 @@
     provider: https://bob.example/
     receiver: https://manufacturing.example/
     resourceClassifiedAs: https://www.wikidata.org/wiki/Q192047 # machining
-    affectedQuantity:
+    observedQuantity:
       qudt:unit: unit:Hour
       qudt:numericValue: 4
     observedTime:

--- a/examples/process-manufacturing.yaml
+++ b/examples/process-manufacturing.yaml
@@ -52,8 +52,8 @@
     action: consume
     provider: https://manufacturing.example/
     receiver: https://manufacturing.example/
-    affects: mfg:3129ca8b-fcda-45be-bbda-294dc924d3b9 # plywood sheets
-    affectedQuantity:
+    involves: mfg:3129ca8b-fcda-45be-bbda-294dc924d3b9 # plywood sheets
+    observedQuantity:
       qudt:unit: unit:Number
       qudt:numericValue: 3
 
@@ -63,8 +63,8 @@
     action: use
     provider: https://manufacturing.example/
     receiver: https://manufacturing.example/
-    affects: mfg:52f0e212-3c4f-4d27-b345-5e964c135824 # CNC machine
-    affectedQuantity:
+    involves: mfg:52f0e212-3c4f-4d27-b345-5e964c135824 # CNC machine
+    observedQuantity:
       qudt:unit: unit:Hour
       qudt:numericValue: 3.5
 
@@ -74,8 +74,8 @@
     action: cite
     provider: https://makezine.com/
     receiver: https://manufacturing.example/
-    affects: mfg:6b97b1be-8e07-44ac-82e5-214f1b2aaf33 # desk design specification
-    affectedQuantity:
+    involves: mfg:6b97b1be-8e07-44ac-82e5-214f1b2aaf33 # desk design specification
+    observedQuantity:
       qudt:unit: unit:Number
       qudt:numericValue: 1
 
@@ -86,7 +86,7 @@
     provider: https://alice.example/
     receiver: https://manufacturing.example/
     resourceClassifiedAs: https://www.wikidata.org/wiki/Q192047 # machining
-    affectedQuantity:
+    observedQuantity:
       qudt:unit: unit:Hour
       qudt:numericValue: 7
 
@@ -96,8 +96,8 @@
     action: produce
     provider: https://manufacturing.example/
     receiver: https://manufacturing.example/
-    affects: mfg:e1721a61-cd47-4556-84b9-8b1b81da15bf # desk
-    affectedQuantity:
+    involves: mfg:e1721a61-cd47-4556-84b9-8b1b81da15bf # desk
+    observedQuantity:
       qudt:unit: unit:Number
       qudt:numericValue: 1
 

--- a/examples/process-workflow.yaml
+++ b/examples/process-workflow.yaml
@@ -31,8 +31,8 @@
     action: accept
     provider: https://alice.example/
     receiver: https://auto-repair.example/
-    affects: alice:e1721a61-cd47-4556-84b9-8b1b81da15bf
-    affectedQuantity:
+    involves: alice:e1721a61-cd47-4556-84b9-8b1b81da15bf
+    observedQuantity:
       qudt:unit: unit:Number
       qudt:numericValue: 1
 
@@ -42,8 +42,8 @@
     action: improve
     provider: https://auto-repair.example/
     receiver: https://alice.example/
-    affects: alice:e1721a61-cd47-4556-84b9-8b1b81da15bf
-    affectedQuantity:
+    involves: alice:e1721a61-cd47-4556-84b9-8b1b81da15bf
+    observedQuantity:
       qudt:unit: unit:Number
       qudt:numericValue: 1
 

--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -376,6 +376,13 @@ vf:intendedTime a           owl:ObjectProperty ;
         vs:term_status      "unstable" ;
         rdfs:comment        "The intended temporal instant or interval." .
 
+vf:satisfiedTime a          owl:ObjectProperty ;
+        rdfs:label          "satisfied time" ;
+        rdfs:domain         vf:Satsifaction ;
+        rdfs:range          time:TemporalEntity ;
+        vs:term_status      "unstable" ;
+        rdfs:comment        "For satisfaction involving scheduling, the satisfied portion of the time." .
+
 vf:plannedTime a            owl:ObjectProperty ;
         rdfs:label          "planned time" ;
         rdfs:domain         vf:Process ;

--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -292,26 +292,33 @@ vf:currentQuantity a        owl:ObjectProperty ;
         vs:term_status      "unstable" ;
         rdfs:comment        "The current amount and unit of the economic resource. This can be stored or derived from economic events affecting the resource" .
 
-vf:observedQuantity a       owl:ObjectProperty ;
-        rdfs:label          "observed quantity" ;
-        rdfs:domain         vf:EconomicEvent ;
+vf:flowQuantity a           owl:ObjectProperty ;
+        rdfs:label          "flow quantity" ;
+        rdfs:domain         [ owl:unionOf (vf:EconomicEvent vf:Commitment vf:Intent) ] ;
         rdfs:range          qudt:QuantityValue ;
         vs:term_status      "unstable" ;
-        rdfs:comment        "The amount and unit of the event. This is the quantity that could be used to increment or decrement a resource, depending on the type of resource and type of event.  It is also used in counting or accounting functions, and exchanges." .
+        rdfs:comment        "The numeric value and unit of the event, commitment, or intent." .
 
-vf:committedQuantity a      owl:ObjectProperty ;
-        rdfs:label          "committed quantity" ;
-        rdfs:domain         vf:Commitment ;
-        rdfs:range          qudt:QuantityValue ;
-        vs:term_status      "unstable" ;
-        rdfs:comment        "The amount and unit of the commitment." .
+#vf:observedQuantity a       owl:ObjectProperty ;
+#        rdfs:label          "observed quantity" ;
+#        rdfs:domain         vf:EconomicEvent ;
+#        rdfs:range          qudt:QuantityValue ;
+#        vs:term_status      "unstable" ;
+#        rdfs:comment        "The amount and unit of the event. This is the quantity that could be used to increment or decrement a resource, depending on the type of resource and type of event.  It is also used in counting or accounting functions, and exchanges." .
 
-vf:intendedQuantity a       owl:ObjectProperty ;
-        rdfs:label          "intended quantity" ;
-        rdfs:domain         vf:Intent ;
-        rdfs:range          qudt:QuantityValue ;
-        vs:term_status      "unstable" ;
-        rdfs:comment        "The amount and unit of the intent." .
+#vf:committedQuantity a      owl:ObjectProperty ;
+#        rdfs:label          "committed quantity" ;
+#        rdfs:domain         vf:Commitment ;
+#        rdfs:range          qudt:QuantityValue ;
+#        vs:term_status      "unstable" ;
+#        rdfs:comment        "The amount and unit of the commitment." .
+
+#vf:intendedQuantity a       owl:ObjectProperty ;
+#        rdfs:label          "intended quantity" ;
+#        rdfs:domain         vf:Intent ;
+#        rdfs:range          qudt:QuantityValue ;
+#        vs:term_status      "unstable" ;
+#        rdfs:comment        "The amount and unit of the intent." .
 
 vf:fulfilledQuantity a      owl:ObjectProperty ;
         rdfs:label          "fulfilled quantity" ;
@@ -355,26 +362,33 @@ vf:primaryLocation a        owl:ObjectProperty ;
         vs:term_status      "unstable" ;
         rdfs:comment        "The main place an agent is located, often an address where activities occur and mail can be sent. This is usually a mappable geographic location.  It also could be a website address, as in the case of agents who have no physical location." .
 
-vf:observedTime a           owl:ObjectProperty ;
-        rdfs:label          "observed time" ;
-        rdfs:domain         vf:EconomicEvent ;
+vf:flowTime a               owl:ObjectProperty ;
+        rdfs:label          "flow time" ;
+        rdfs:domain         [ owl:unionOf (vf:EconomicEvent vf:Commitment vf:Intent) ] ;
         rdfs:range          [ time:TemporalEntity time:Instant ] ;
         vs:term_status      "unstable" ;
-        rdfs:comment        "The actual temporal instant or interval." .
+        rdfs:comment        "The temporal instant or interval of the event, commitment, or intent." .
 
-vf:committedTime a          owl:ObjectProperty ;
-        rdfs:label          "committed time" ;
-        rdfs:domain         vf:Commitment ;
-        rdfs:range          [ time:TemporalEntity time:Instant ] ;
-        vs:term_status      "unstable" ;
-        rdfs:comment        "The promised temporal instant or interval." .
+#vf:observedTime a           owl:ObjectProperty ;
+#        rdfs:label          "observed time" ;
+#        rdfs:domain         vf:EconomicEvent ;
+#        rdfs:range          [ time:TemporalEntity time:Instant ] ;
+#        vs:term_status      "unstable" ;
+#        rdfs:comment        "The actual temporal instant or interval." .
 
-vf:intendedTime a           owl:ObjectProperty ;
-        rdfs:label          "intended time" ;
-        rdfs:domain         vf:Intent ;
-        rdfs:range          [ time:TemporalEntity time:Instant ] ;
-        vs:term_status      "unstable" ;
-        rdfs:comment        "The intended temporal instant or interval." .
+#vf:committedTime a          owl:ObjectProperty ;
+#        rdfs:label          "committed time" ;
+#        rdfs:domain         vf:Commitment ;
+#        rdfs:range          [ time:TemporalEntity time:Instant ] ;
+#        vs:term_status      "unstable" ;
+#        rdfs:comment        "The promised temporal instant or interval." .
+
+#vf:intendedTime a           owl:ObjectProperty ;
+#        rdfs:label          "intended time" ;
+#        rdfs:domain         vf:Intent ;
+#        rdfs:range          [ time:TemporalEntity time:Instant ] ;
+#        vs:term_status      "unstable" ;
+#        rdfs:comment        "The intended temporal instant or interval." .
 
 vf:satisfiedTime a          owl:ObjectProperty ;
         rdfs:label          "satisfied time" ;

--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -358,21 +358,21 @@ vf:primaryLocation a        owl:ObjectProperty ;
 vf:observedTime a           owl:ObjectProperty ;
         rdfs:label          "observed time" ;
         rdfs:domain         vf:EconomicEvent ;
-        rdfs:range          time:TemporalEntity ;
+        rdfs:range          [ time:TemporalEntity time:Instant ] ;
         vs:term_status      "unstable" ;
         rdfs:comment        "The actual temporal instant or interval." .
 
 vf:committedTime a          owl:ObjectProperty ;
         rdfs:label          "committed time" ;
         rdfs:domain         vf:Commitment ;
-        rdfs:range          time:TemporalEntity ;
+        rdfs:range          [ time:TemporalEntity time:Instant ] ;
         vs:term_status      "unstable" ;
         rdfs:comment        "The promised temporal instant or interval." .
 
 vf:intendedTime a           owl:ObjectProperty ;
         rdfs:label          "intended time" ;
         rdfs:domain         vf:Intent ;
-        rdfs:range          time:TemporalEntity ;
+        rdfs:range          [ time:TemporalEntity time:Instant ] ;
         vs:term_status      "unstable" ;
         rdfs:comment        "The intended temporal instant or interval." .
 

--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -178,10 +178,10 @@ vf:recipeOutputOf
 vf:involves
         a                   owl:ObjectProperty ;
         rdfs:label          "involves" ;
-        rdfs:domain         [ owl:unionOf (vf:Commitment vf:Intent) ] ; 
+        rdfs:domain         [ owl:unionOf (vf:Commitment vf:Intent vf:EconomicEvent) ] ; 
         rdfs:range          vf:EconomicResource ;
         vs:term_status      "unstable" ;
-        rdfs:comment        "Economic resource the commitment commits or the intent intends to affect. Could be an actual resource or a classification / specification of resource." .
+        rdfs:comment        "Economic resource referenced by a flow, which could be decremented or incremented, or just what the flow is about." .
 
 vf:underlyingResource
         a                   owl:ObjectProperty ;
@@ -198,13 +198,13 @@ vf:relationship  a          owl:ObjectProperty ;
         vs:term_status      "unstable" ;
         rdfs:comment        "A kind of relationship that exists between 2 agents." .
 
-vf:affects
-        a                   owl:ObjectProperty ;
-        rdfs:label          "affects" ;
-        rdfs:domain         vf:EconomicEvent ;
-        rdfs:range          vf:EconomicResource ;
-        vs:term_status      "unstable" ;
-        rdfs:comment        "The economic resource that is decremented or incremented by the economic event, or just what the economic event is about." .
+#vf:affects
+#        a                   owl:ObjectProperty ;
+#        rdfs:label          "affects" ;
+#        rdfs:domain         vf:EconomicEvent ;
+#        rdfs:range          vf:EconomicResource ;
+#        vs:term_status      "unstable" ;
+#        rdfs:comment        "The economic resource that is decremented or incremented by the economic event, or just what the economic event is about." .
 
 vf:appreciationOf
         a                   owl:ObjectProperty ;
@@ -292,12 +292,12 @@ vf:currentQuantity a        owl:ObjectProperty ;
         vs:term_status      "unstable" ;
         rdfs:comment        "The current amount and unit of the economic resource. This can be stored or derived from economic events affecting the resource" .
 
-vf:affectedQuantity a       owl:ObjectProperty ;
-        rdfs:label          "affected quantity" ;
+vf:observedQuantity a       owl:ObjectProperty ;
+        rdfs:label          "observed quantity" ;
         rdfs:domain         vf:EconomicEvent ;
         rdfs:range          qudt:QuantityValue ;
         vs:term_status      "unstable" ;
-        rdfs:comment        "The amount and unit of the event. This is the quantity that could be used to increment or decrement a resource, depending on the type of resource and type of event." .
+        rdfs:comment        "The amount and unit of the event. This is the quantity that could be used to increment or decrement a resource, depending on the type of resource and type of event.  It is also used in counting or accounting functions, and exchanges." .
 
 vf:committedQuantity a      owl:ObjectProperty ;
         rdfs:label          "committed quantity" ;


### PR DESCRIPTION
working with core attributes for a minimal PR, started with 'affects' and 'affectedQuantity'

question: On the time properties, if we think they will be either an Instant or a TemporalEntity (Instant being a subclass of TemporalEntity), should we explicitly define the rdfs:range to be both of those, or leave it at TemporalEntity and let the examples speak?