### PR TITLE
simpler time format

### DIFF
--- a/examples/fulfill-satisfy.yaml
+++ b/examples/fulfill-satisfy.yaml
@@ -20,13 +20,8 @@
       qudt:unit: unit:Hour
       qudt:numericValue: 8
     intendedTime:
-      '@type': time:ProperInterval
-      time:intervalStarts:
-        '@type': time:Instant
-        time:inXSDDateTimeStamp: 2018-10-14T8:00:00-0:00
-      time:intervalEnds:
-        '@type': time:Instant
-        time:inXSDDateTimeStamp: 2018-10-15T18:00:00-0:00
+      hasBeginning: 2018-10-14T8:00:00-0:00
+      hasEnd: 2018-10-15T18:00:00-0:00
 
   # Bob commits to doing the work on Oct. 14
 
@@ -40,14 +35,8 @@
       qudt:unit: unit:Hour
       qudt:numericValue: 8
     committedTime:
-      '@type': time:ProperInterval
-      time:intervalStarts:
-        '@type': time:Instant
-        time:inXSDDateTimeStamp: 2018-10-14T8:00:00-0:00
-      time:intervalEnds:
-        '@type': time:Instant
-        time:inXSDDateTimeStamp: 2018-10-14T17:00:00-0:00
-
+      hasBeginning: 2018-10-14T8:00:00-0:00
+      hasEnd: 2018-10-14T17:00:00-0:00
 
   - '@id': mfg:b52a5815-fae9-43bf-be95-833b95dc0adb
     '@type': Satisfaction
@@ -69,13 +58,8 @@
       qudt:unit: unit:Hour
       qudt:numericValue: 4
     observedTime:
-      '@type': time:ProperInterval
-      time:intervalStarts:
-        '@type': time:Instant
-        time:inXSDDateTimeStamp: 2018-10-14T8:00:00-0:00
-      time:intervalEnds:
-        '@type': time:Instant
-        time:inXSDDateTimeStamp: 2018-10-14T12:00:00-0:00
+      hasBeginning: 2018-10-14T8:00:00-0:00
+      hasEnd: 2018-10-14T12:00:00-0:00
 
   - '@id': mfg:6f438393-7f87-4914-806c-e23a4fd15e89
     '@type': Fulfillment
@@ -95,13 +79,8 @@
       qudt:unit: unit:Hour
       qudt:numericValue: 4
     observedTime:
-      '@type': time:ProperInterval
-      time:intervalStarts:
-        '@type': time:Instant
-        time:inXSDDateTimeStamp: 2018-10-14T13:00:00-0:00
-      time:intervalEnds:
-        '@type': time:Instant
-        time:inXSDDateTimeStamp: 2018-10-14T17:00:00-0:00
+      hasBeginning: 2018-10-14T13:00:00-0:00
+      hasEnd: 2018-10-14T17:00:00-0:00
 
   - '@id': mfg:0f563083-8da4-46fe-adc3-68b05ba06320
     '@type': Fulfillment


### PR DESCRIPTION
Trying to get the time formatting nailed down so I can get it properly into the graphql reference.  This is in some of your examples @elf-pavlik but I'm not sure it is valid owl/rdf, assuming the time: is in the context?  I hope so, I like it....

Other question:  How would we do an instant?  Would we just need both properties hasBeginning and hasEnd?  Or can we get away with one or the other?  Or would we need something different? I think you answered some of this somewhere, but I have looked and can't find it.

And one more: Is our rdfs:range still correct for this example?  Like here:
```
vf:observedTime a           owl:ObjectProperty ;
        rdfs:label          "observed time" ;
        rdfs:domain         vf:EconomicEvent ;
        rdfs:range          time:TemporalEntity ;
        vs:term_status      "unstable" ;
        rdfs:comment        "The actual temporal instant or interval." .
```