### PR TITLE
TemporalDuration > Duration

### DIFF
--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -453,7 +453,7 @@ vf:unit a                   owl:ObjectProperty ;
 vf:duration a               owl:ObjectProperty ;
         rdfs:label          "duration" ;
         rdfs:domain         vf:RecipeProcess ;
-        rdfs:range          time:TemporalDuration ;
+        rdfs:range          time:Duration ;
         vs:term_status      "unstable" ;
         rdfs:comment        "The calendar duration defined for this type of process." .
 

--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -450,13 +450,6 @@ vf:unit a                   owl:ObjectProperty ;
 #        vs:term_status      "unstable" ;
 #        rdfs:comment    "This recipe is an updated version of another recipe." .
 
-vf:duration a               owl:ObjectProperty ;
-        rdfs:label          "duration" ;
-        rdfs:domain         vf:RecipeProcess ;
-        rdfs:range          time:Duration ;
-        vs:term_status      "unstable" ;
-        rdfs:comment        "The calendar duration defined for this type of process." .
-
 vf:durationMultiplier 
         a                   owl:DatatypeProperty ;
         rdfs:label          "duration multiplier" ;


### PR DESCRIPTION
made the Process.duration more specific, limiting the fields that people would use a bit - unitType, numericDuration

ref. https://www.w3.org/TR/owl-time/#duration