### PR TITLE
changing name of involves

### DIFF
--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -175,9 +175,9 @@ vf:recipeOutputOf
         vs:term_status      "unstable" ;
         rdfs:comment        "Relates an output flow to it's node in a recipe." .
 
-vf:involves
+vf:resourceInventoriedAs
         a                   owl:ObjectProperty ;
-        rdfs:label          "involves" ;
+        rdfs:label          "resource inventoried as" ;
         rdfs:domain         [ owl:unionOf (vf:Commitment vf:Intent vf:EconomicEvent) ] ; 
         rdfs:range          vf:EconomicResource ;
         vs:term_status      "unstable" ;


### PR DESCRIPTION
involves > resourceInventoriedAs in the flows

much clearer name, and also groups better conceptually with resourceClassifiedAs and resourceConformsTo, clarifying these together give you what is known about the little-r resource

[edit If there is agreement, I'll also change the existing examples and add here, or do as a separate PR right away]