### PR TITLE
claim model

### DIFF
--- a/docs/introduction/flows.md
+++ b/docs/introduction/flows.md
@@ -19,6 +19,10 @@ Commitments describe potential future events which the involved agents already a
 
 Economic Events describes past events, something observed, never some potential future event.  They can fulfill Commitments or satisfy Intents (when there is no Commitment).
 
+## Claims
+
+Claims resemble commitments, but are initiated by the receiver, not the provider.  An economic event can trigger a reciprocal claim.  Claims do not have to be instantiated, often they can be implied from an economic event and an agreement.
+
 ## Timeline, plans and observations
 
 Figure below shows that Economic Events have to be observed and for that reason only appear as records of the past. Future plans get represented with Intents and Commitments.

--- a/examples/claim.yaml
+++ b/examples/claim.yaml
@@ -1,0 +1,59 @@
+# Example: Claim (simple)
+
+'@context':
+  - https://git.io/vf-examples-jsonld-context
+  - bob: https://bob.example/
+    mfg: https://manufacturer.example/
+
+'@id': rgh:valueflows/valueflows/master/examples/claim.yaml
+'@graph':
+
+  # Bob does some work to create a product that the mfg team wishes to sell on the marketplace
+
+  - '@id': mfg:02b39a30-3e04-4305-9656-7f261aa63c83
+    '@type': EconomicEvent
+    action: work
+    provider: https://bob.example/
+    receiver: https://manufacturing.example/
+    resourceClassifiedAs: https://www.wikidata.org/wiki/Q192047 # machining
+    quantifiedAs:
+      qudt:unit: unit:Hour
+      qudt:numericValue: 7
+    hasBeginning: 2018-10-14T8:00:00-0:00
+    hasEnd: 2018-10-14T15:00:00-0:00
+
+  # this triggers a claim for payment in the future based on an income distribution agreement among the mfg group
+
+  - '@id': mfg:d4d2fd71-34f2-41c3-b1c5-19ad5ed2da58
+    '@type': Claim
+    action: receive
+    provider: https://manufacturing.example/
+    receiver: https://bob.example/
+    resourceClassifiedAs: https://www.wikidata.org/wiki/Q1104069 # Canadian dollar
+    quantifiedAs:
+      qudt:unit: unit:Number
+      qudt:numericValue: 140
+    dcterms:created: 2018-10-14T15:30:00-0:00
+    triggeredBy: mfg:02b39a30-3e04-4305-9656-7f261aa63c83
+    under: mfg:e1721a61-cd47-4556-84b9-8b1b81da15be # a distribution agreement (not detailed in example)
+
+  # half of the manufactured product is sold along with some other products, and income is distributed
+
+  - '@id': mfg:c7897c39-7f05-4a5d-a487-80e130a2414a
+    '@type': EconomicEvent
+    action: receive
+    provider: https://bob.example/
+    receiver: https://manufacturing.example/
+    resourceClassifiedAs: https://www.wikidata.org/wiki/Q1104069 # Canadian dollar
+    quantifiedAs:
+      qudt:unit: unit:Number
+      qudt:numericValue: 260 # here Bob received income for more than one work event (others not included in the example)
+    time:inXSDDateTimeStamp: 2018-10-25T09:30:00-0:00
+
+  - '@id': mfg:b52a5815-fae9-43bf-be95-833b95dc0ada
+    '@type': Settlement
+    settles: mfg:d4d2fd71-34f2-41c3-b1c5-19ad5ed2da58 # the claim
+    settlededBy: mfg:c7897c39-7f05-4a5d-a487-80e130a2414a # the economic event
+    setledQuantity:
+      qudt:unit: unit:Number
+      qudt:numericValue: 70 # half of the original claim for the work

--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -117,8 +117,13 @@ vf:Fulfillment  a           owl:Class ;
         vs:term_status      "unstable" ;
         rdfs:comment        "The quantity that the economic event fulfilled towards the commitment." .
 
-vf:Claim  a           owl:Class ;
+vf:Claim  a                 owl:Class ;
         rdfs:label          "vf:Claim" ;
+        vs:term_status      "unstable" ;
+        rdfs:comment        "." .
+
+vf:Settlement  a            owl:Class ;
+        rdfs:label          "vf:Settlement" ;
         vs:term_status      "unstable" ;
         rdfs:comment        "." .
 
@@ -256,19 +261,26 @@ vf:under  a                 owl:ObjectProperty ;
         vs:term_status      "unstable" ;
         rdfs:comment        "Reference to an agreement between agents which specifies the rules or policies or calculations which govern this flow." .
 
-vf:materializes  a          owl:ObjectProperty ;
-        rdfs:label          "materializes" ;
+vf:triggeredBy  a           owl:ObjectProperty ;
+        rdfs:label          "triggered by" ;
         rdfs:domain         vf:Claim ;
         rdfs:range          vf:EconomicEvent ;
         vs:term_status      "unstable" ;
-        rdfs:comment        "References an economic event that fully or partially implied the claim, often based on a prior agreement." .
+        rdfs:comment        "References an economic event that implied the claim, often based on a prior agreement." .
 
 vf:settles  a               owl:ObjectProperty ;
         rdfs:label          "settles" ;
-        rdfs:domain         vf:Claim ;
-        rdfs:range          vf:Commitment ;
+        rdfs:domain         vf:Settlement ;
+        rdfs:range          vf:Claim ;
         vs:term_status      "unstable" ;
-        rdfs:comment        "References an economic event that fully or partially settles the claim, often based on a prior agreement." .
+        rdfs:comment        "References a claim that fully or partially settled by the economic event.
+
+vf:settledBy  a             owl:ObjectProperty ;
+        rdfs:label          "settled by" ;
+        rdfs:domain         vf:Settlement ;
+        rdfs:range          vf:EconomicEvent ;
+        vs:term_status      "unstable" ;
+        rdfs:comment        "References an economic event that fully or partially settles the claim." .
 
 vf:contains a               owl:ObjectProperty ;
         rdfs:label          "contains" ;
@@ -337,13 +349,6 @@ vf:claimedQuantity a        owl:ObjectProperty ;
         rdfs:range          qudt:QuantityValue ;
         vs:term_status      "unstable" ;
         rdfs:comment        "The quantity of the initial expected reciprocity when an event materializes a claim." .
-
-vf:remainingQuantity a      owl:ObjectProperty ;
-        rdfs:label          "remaining quantity" ;
-        rdfs:domain         vf:Claim ;
-        rdfs:range          qudt:QuantityValue ;
-        vs:term_status      "unstable" ;
-        rdfs:comment        "The quantity not yet received of the expected reciprocity when an event materializes a claim." .
 
 vf:definedQuantity a        owl:ObjectProperty ;
         rdfs:label          "defined quantity" ;

--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -273,7 +273,7 @@ vf:settles  a               owl:ObjectProperty ;
         rdfs:domain         vf:Settlement ;
         rdfs:range          vf:Claim ;
         vs:term_status      "unstable" ;
-        rdfs:comment        "References a claim that fully or partially settled by the economic event.
+        rdfs:comment        "References a claim that fully or partially settled by the economic event." .
 
 vf:settledBy  a             owl:ObjectProperty ;
         rdfs:label          "settled by" ;

--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -117,10 +117,10 @@ vf:Fulfillment  a           owl:Class ;
         vs:term_status      "unstable" ;
         rdfs:comment        "The quantity that the economic event fulfilled towards the commitment." .
 
-#vf:Reciprocity  a           owl:Class ;
-#        rdfs:label          "vf:Reciprocity" ;
-#        vs:term_status      "unstable" ;
-#        rdfs:comment        "The quantity that the economic event implies towards creation of the reciprocal commitment." .
+vf:Claim  a           owl:Class ;
+        rdfs:label          "vf:Claim" ;
+        vs:term_status      "unstable" ;
+        rdfs:comment        "." .
 
 vf:Appreciation  a          owl:Class ;
         rdfs:label          "vf:Appreciation" ;
@@ -138,7 +138,7 @@ vf:Appreciation  a          owl:Class ;
 vf:action
         a                   owl:ObjectProperty ;
         rdfs:label          "action" ;
-        rdfs:domain         [ owl:unionOf (vf:EconomicEvent vf:Commitment vf:Intent vf:RecipeFlow) ] ;
+        rdfs:domain         [ owl:unionOf (vf:EconomicEvent vf:Commitment vf:Intent vf:RecipeFlow vf:Claim) ] ;
         rdfs:range          vf:Action ;
         vs:term_status      "unstable" ;
         rdfs:comment        "Relates a process input or output to a verb, such as consume, produce, work, improve, etc." .
@@ -215,14 +215,14 @@ vf:appreciationWith
         rdfs:comment        "The economic event implemented in appreciation (gift economy)." .
 
 vf:provider  a              owl:ObjectProperty ;
-        rdfs:domain         [ owl:unionOf (vf:EconomicEvent vf:Commitment vf:Intent) ] ;
+        rdfs:domain         [ owl:unionOf (vf:EconomicEvent vf:Commitment vf:Intent vf:Claim) ] ;
         rdfs:label          "provider" ;
         rdfs:range          foaf:Agent ;
         vs:term_status      "testing" ;
         rdfs:comment        "The economic agent from whom the intended, committed, or actual economic event is initiated." .
 
 vf:receiver  a              owl:ObjectProperty ;
-        rdfs:domain         [ owl:unionOf (vf:EconomicEvent vf:Commitment vf:Intent) ] ;
+        rdfs:domain         [ owl:unionOf (vf:EconomicEvent vf:Commitment vf:Intent vf:Claim) ] ;
         rdfs:label          "receiver" ;
         rdfs:range          foaf:Agent ;
         vs:term_status      "testing" ;
@@ -250,25 +250,25 @@ vf:inScopeOf  a             owl:ObjectProperty ;
         rdfs:comment        "Grouping around something to create a boundary or context, used for documenting, accounting, planning." .
 
 vf:under  a                 owl:ObjectProperty ;
-        rdfs:domain         [ owl:unionOf (vf:EconomicEvent vf:Commitment vf:Intent vf:Fulfillment ) ] ; 
+        rdfs:domain         [ owl:unionOf (vf:EconomicEvent vf:Commitment vf:Intent vf:Fulfillment vf:Claim) ] ; 
         rdfs:label          "under" ;
         rdfs:range          vf:Agreement ;
         vs:term_status      "unstable" ;
         rdfs:comment        "Reference to an agreement between agents which specifies the rules or policies or calculations which govern this flow." .
 
-#vf:createdBy  a             owl:ObjectProperty ;
-#        rdfs:label          "created by" ;
-#        rdfs:domain         vf:Reciprocity ;
-#        rdfs:range          vf:EconomicEvent ;
-#        vs:term_status      "unstable" ;
-#        rdfs:comment        "References the economic event that fully or partially created the commitment, often based on a prior agreement." .
+vf:materializes  a          owl:ObjectProperty ;
+        rdfs:label          "materializes" ;
+        rdfs:domain         vf:Claim ;
+        rdfs:range          vf:EconomicEvent ;
+        vs:term_status      "unstable" ;
+        rdfs:comment        "References an economic event that fully or partially implied the claim, often based on a prior agreement." .
 
-#vf:creates  a               owl:ObjectProperty ;
-#        rdfs:label          "creates" ;
-#        rdfs:domain         vf:Reciprocity ;
-#        rdfs:range          vf:Commitment ;
-#        vs:term_status      "unstable" ;
-#        rdfs:comment        "References the commitment that was fully or partially created because of the economic event, often based on a prior agreement." .
+vf:settles  a               owl:ObjectProperty ;
+        rdfs:label          "settles" ;
+        rdfs:domain         vf:Claim ;
+        rdfs:range          vf:Commitment ;
+        vs:term_status      "unstable" ;
+        rdfs:comment        "References an economic event that fully or partially settles the claim, often based on a prior agreement." .
 
 vf:contains a               owl:ObjectProperty ;
         rdfs:label          "contains" ;
@@ -331,12 +331,19 @@ vf:satisfiedQuantity a      owl:ObjectProperty ;
         vs:term_status      "unstable" ;
         rdfs:comment        "The quantity of the satisfaction of an commitment towards an intent." .
 
-#vf:reciprocalQuantity a     owl:ObjectProperty ;
-#        rdfs:label          "reciprocal quantity" ;
-#        rdfs:domain         vf:Reciprocity ;
-#        rdfs:range          qudt:QuantityValue ;
-#        vs:term_status      "unstable" ;
-#        rdfs:comment        "The quantity of the reciprocity when an event creates a commitment." .
+vf:claimedQuantity a        owl:ObjectProperty ;
+        rdfs:label          "claimed quantity" ;
+        rdfs:domain         vf:Claim ;
+        rdfs:range          qudt:QuantityValue ;
+        vs:term_status      "unstable" ;
+        rdfs:comment        "The quantity of the initial expected reciprocity when an event materializes a claim." .
+
+vf:remainingQuantity a      owl:ObjectProperty ;
+        rdfs:label          "remaining quantity" ;
+        rdfs:domain         vf:Claim ;
+        rdfs:range          qudt:QuantityValue ;
+        vs:term_status      "unstable" ;
+        rdfs:comment        "The quantity not yet received of the expected reciprocity when an event materializes a claim." .
 
 vf:definedQuantity a        owl:ObjectProperty ;
         rdfs:label          "defined quantity" ;
@@ -409,7 +416,7 @@ vf:satisfiedBy
         rdfs:comment        "A commitment or economic event fully or partially satisfying an intent" .
 
 vf:finished  a              owl:DatatypeProperty ;
-        rdfs:domain         [ owl:unionOf (vf:Commitment vf:Process vf:Intent) ] ; 
+        rdfs:domain         [ owl:unionOf (vf:Commitment vf:Process vf:Intent vf:Claim) ] ; 
         rdfs:label          "finished" ;
         rdfs:range          xsd:boolean ;
         vs:term_status      "testing" ;
@@ -477,7 +484,7 @@ vf:classifiedAs
 vf:resourceClassifiedAs
         a                   owl:ObjectProperty ;
         rdfs:label          "resource classified as" ;
-        rdfs:domain         [ owl:unionOf (vf:ResourceSpecification vf:Intent vf:Commitment vf:EconomicEvent vf:RecipeFlow) ] ;
+        rdfs:domain         [ owl:unionOf (vf:ResourceSpecification vf:Intent vf:Commitment vf:EconomicEvent vf:RecipeFlow vf:Claim) ] ;
         rdfs:range          owl:Thing ;
         vs:term_status      "unstable" ;
         rdfs:comment        "References a concept in a common taxonomy or other classification scheme for purposes of categorization." .
@@ -493,7 +500,7 @@ vf:processClassifiedAs
 vf:resourceConformsTo
         a                   owl:ObjectProperty ;
         rdfs:label          "resource conforms to" ;
-        rdfs:domain         [ owl:unionOf (vf:Commitment vf:EconomicResource vf:Intent vf:RecipeFlow vf:EconomicEvent ) ] ;
+        rdfs:domain         [ owl:unionOf (vf:Commitment vf:EconomicResource vf:Intent vf:RecipeFlow vf:EconomicEvent vf:Claim ) ] ;
         rdfs:range          vf:ResourceSpecification ;
         vs:term_status      "unstable" ;
         rdfs:comment        "The primary resource knowledge specification or definition of an existing or potential resource." .


### PR DESCRIPTION
@elf-pavlik @bhaugen 
This is to replace the removed Reciprocity, which created Commitments from Economic Events.  It was observed that Claims are different than Commitments because commitments can only be committed by the provider, while claims are initiated by the hopeful receiver.

Model looks like this.  Claim has most of the properties of I-C-E- flows.  Claim basically references both the event(s) that triggered the claim and the event(s) that resolve the claim.  [edit: WRONG model, see following comments]
![claim](https://user-images.githubusercontent.com/3776081/56092691-ab0d9980-5e84-11e9-8c91-8424fc13823e.png)

I included a brief description in the flows page.  Probably a lot more could be said eventually.

The terms are straight out of McCarthy / REA.  

Note REA people also talk about claims and 'negative claims'.  Negative claims are things like issuing dividends.  I haven't defined those here, not sure if we want to do that, or consider those commitments.  My impression is the 'negative' term comes from enterprise perspective, not independent perspective.  And if an agent doesn't get their dividend as expected, they could issue a regular claim.