### PR TITLE
recreate agreement relationships

### DIFF
--- a/examples/exch-agreement.yaml
+++ b/examples/exch-agreement.yaml
@@ -1,0 +1,68 @@
+# Example: Simple exchange agreements
+
+'@context':
+  - https://git.io/vf-examples-jsonld-context
+  - alice: https://alice.example/
+    bob: https://bob.example/
+    carol: https://carol.example/
+    store: https://store.example/
+
+'@id': rgh:valueflows/valueflows/master/examples/exch-agreement.yaml
+'@graph':
+
+  # Exchange agreement with commitments
+
+  - '@id': alice:57f1c1d0-432e-4bfa-9d32-002b8955a708
+    '@type': Agreement
+    skos:note: Alice commits to giving Bob 50 kg of apples in exchange for 10 liters of apple cider.
+
+  - '@id': alice:2342d456-5d6f-46d5-a7ed-3ac7bfd5a86c
+    '@type': Commitment
+    clauseOf: alice:57f1c1d0-432e-4bfa-9d32-002b8955a708
+    action: give
+    provider: https://alice.example/
+    receiver: https://bob.example/
+    resourceClassifiedAs: https://www.wikidata.org/wiki/Q89 # apples
+    quantifiedAs:
+      qudt:unit: unit: Kilogram
+      qudt:numericValue: 50
+
+  - '@id': bob:fd399b37-0740-4a68-a184-1e655021ca21
+    '@type': Commitment
+    clauseOf: alice:57f1c1d0-432e-4bfa-9d32-002b8955a708
+    action: give
+    provider: https://bob.example/
+    receiver: https://alice.example/
+    resourceClassifiedAs: https://www.wikidata.org/wiki/Q5977438 # soft apple cider
+    quantifiedAs:
+      qudt:unit: unit: Liter
+      qudt:numericValue: 10
+
+  # Exchange without commitments
+
+  - '@id': store:ac9ec98d-db80-44dc-97be-7aa149b2fe5d
+    '@type': Agreement
+    skos:note: Carol purchased a new bucket at the hardware store and paid 5 dollars for it.
+
+  - '@id': store:a8356625-bf64-4c16-9099-28aa1b718c4b
+    '@type': EconomicEvent
+    realizationOf: store:ac9ec98d-db80-44dc-97be-7aa149b2fe5d
+    action: give
+    provider: https://store.example/
+    receiver: https://carol.example/
+    resourceClassifiedAs: https://www.wikidata.org/wiki/Q47107 # bucket
+    quantifiedAs:
+      qudt:unit: unit: Number
+      qudt:numericValue: 1
+
+  - '@id': store:a8356625-bf64-4c16-9099-28aa1b718c4b
+    '@type': EconomicEvent
+    realizationOf: store:ac9ec98d-db80-44dc-97be-7aa149b2fe5d
+    action: give
+    provider: https://carol.example/
+    receiver: https://store.example/
+    resourceClassifiedAs: https://www.wikidata.org/wiki/Q4917 # US dollar
+    resourceInventoriedAs: carol:e56fd654-7b94-4d96-8e60-de39e08329a7 # Carol's bank account
+    quantifiedAs:
+      qudt:unit: unit: Number
+      qudt:numericValue: 5

--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -70,19 +70,7 @@ vf:Satisfaction  a          owl:Class ;
 vf:Agreement  a             owl:Class ;
         rdfs:label          "vf:Agreement" ;
         vs:term_status      "unstable" ;
-        rdfs:comment        "Any type of agreement among economic agents, that can be referenced in VF to clarify the economic activity.  This is a placeholder pending investigating other vocabularies." .
-
-vf:ExchangeAgreement  a     owl:Class ;
-        rdfs:label          "vf:ExchangeAgreement" ;
-        rdfs:subClassOf     vf:Agreement ;
-        vs:term_status      "unstable" ;
-        rdfs:comment        "An agreement to exchange something with another agent(s), containing commitments towards that end." .
-
-vf:DistributionAgreement  a  owl:Class ;
-        rdfs:label           "vf:DistributionAgreement" ;
-        rdfs:subClassOf      vf:Agreement ;
-        vs:term_status      "unstable" ;
-        rdfs:comment         "An agreement to distribute some resource in exchange for inputs or outputs created by other agents." .
+        rdfs:comment        "Any type of agreement among economic agents." .
 
 # OBSERVATION CLASSES
 
@@ -517,7 +505,19 @@ vf:resourceConformsTo
         vs:term_status      "unstable" ;
         rdfs:comment        "The primary resource knowledge specification or definition of an existing or potential resource." .
 
+vf:clauseOf a               owl:ObjectProperty ;
+        rdfs:label          "clause of" ;
+        rdfs:domain         vf:Commitment ;
+        rdfs:range          vf:Agreement ;
+        vs:term_status      "unstable" ;
+        rdfs:comment        "This commitment is part of the agreement, which could not exist without it." .
 
+vf:realizationOf a          owl:ObjectProperty ;
+        rdfs:label          "realization of" ;
+        rdfs:domain         vf:EconomicEvent ;
+        rdfs:range          vf:Agreement ;
+        vs:term_status      "unstable" ;
+        rdfs:comment        "This economic event occurs as part of this exchange." .
 
 # ################################ agent relationship verbs
 

--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -517,7 +517,7 @@ vf:realizationOf a          owl:ObjectProperty ;
         rdfs:domain         vf:EconomicEvent ;
         rdfs:range          vf:Agreement ;
         vs:term_status      "unstable" ;
-        rdfs:comment        "This economic event occurs as part of this exchange." .
+        rdfs:comment        "This economic event occurs as part of this agreement." .
 
 # ################################ agent relationship verbs
 


### PR DESCRIPTION
Recreated from https://github.com/valueflows/valueflows/pull/421.  Basically this adds relationships between Agreement and Commitment / EconomicEvent for agreements that are defined in VF.  Got rid of subclasses of agreement.  I'll close the old one.