### PR TITLE
range of vf:under, removed fulfillment ref

### DIFF
--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -255,11 +255,11 @@ vf:inScopeOf  a             owl:ObjectProperty ;
         rdfs:comment        "Grouping around something to create a boundary or context, used for documenting, accounting, planning." .
 
 vf:under  a                 owl:ObjectProperty ;
-        rdfs:domain         [ owl:unionOf (vf:EconomicEvent vf:Commitment vf:Intent vf:Fulfillment vf:Claim) ] ; 
+        rdfs:domain         [ owl:unionOf (vf:EconomicEvent vf:Commitment vf:Intent vf:Claim) ] ; 
         rdfs:label          "under" ;
-        rdfs:range          vf:Agreement ;
+        rdfs:range          owl:Thing ;
         vs:term_status      "unstable" ;
-        rdfs:comment        "Reference to an agreement between agents which specifies the rules or policies or calculations which govern this flow." .
+        rdfs:comment        "Reference to an agreement between agents which specifies the rules, terms, policies, calculations, etc. which govern this flow." .
 
 vf:triggeredBy  a           owl:ObjectProperty ;
         rdfs:label          "triggered by" ;


### PR DESCRIPTION
Since we got rid of ExchangeAgreement, I'm seeing a need to differentiate the agreements which are part of VF, and will be created along with commitments, etc. and agreements which are just referenced and will not be defined or created as part of VF.  This removes agreements referenced by vf:under from VF.

Also took vf:under off of Fulfillment, probably not needed there, leaving on all the flows.