### PR TITLE
added observedLocation, put other Location refs back

### DIFF
--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -378,12 +378,12 @@ vf:primaryLocation a        owl:ObjectProperty ;
         vs:term_status      "unstable" ;
         rdfs:comment        "The main place an agent is located, often an address where activities occur and mail can be sent. This is usually a mappable geographic location.  It also could be a website address, as in the case of agents who have no physical location." .
 
-vf:observedLocation a       owl:ObjectProperty ;
-        rdfs:label          "observed location" ;
-        rdfs:domain         vf:EconomicEvent ;
+vf:atLocation a             owl:ObjectProperty ;
+        rdfs:label          "at location" ;
+        rdfs:domain         [ owl:unionOf (vf:EconomicEvent vf:Commitment vf:Intent) ] ;  ;
         rdfs:range          vf:Location ;
         vs:term_status      "unstable" ;
-        rdfs:comment        "The place where an economic event occurs.  Usually mappable." .
+        rdfs:comment        "The place where an intent, commitment, or economic event occurs.  Usually mappable." .
 
 vf:image a                  owl:DatatypeProperty ;
         vs:term_status      "unstable" ;

--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -380,7 +380,7 @@ vf:primaryLocation a        owl:ObjectProperty ;
 
 vf:atLocation a             owl:ObjectProperty ;
         rdfs:label          "at location" ;
-        rdfs:domain         [ owl:unionOf (vf:EconomicEvent vf:Commitment vf:Intent) ] ;  ;
+        rdfs:domain         [ owl:unionOf (vf:EconomicEvent vf:Commitment vf:Intent) ] ;
         rdfs:range          vf:Location ;
         vs:term_status      "unstable" ;
         rdfs:comment        "The place where an intent, commitment, or economic event occurs.  Usually mappable." .

--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -132,9 +132,9 @@ vf:Appreciation  a          owl:Class ;
         vs:term_status      "unstable" ;
         rdfs:comment        "A way to tie an economic event that is given in loose fulfilment for another economic event, without commitments or expectations. Supports the gift economy." .
 
-#vf:Location  a              owl:Class ;
-#        vs:term_status      "unstable" ;
-#        rdfs:label          "vf:Location" .
+vf:Location  a              owl:Class ;
+        vs:term_status      "unstable" ;
+        rdfs:label          "vf:Location" .
 
 
 # ####################################################################
@@ -367,16 +367,23 @@ vf:definedQuantity a        owl:ObjectProperty ;
 vf:currentLocation a        owl:ObjectProperty ;
         rdfs:label          "current location" ;
         rdfs:domain         vf:EconomicResource ;
-        #rdfs:range          vf:Location ;
+        rdfs:range          vf:Location ;
         vs:term_status      "unstable" ;
         rdfs:comment        "The current place an economic resource is located.  Could be at any level of granularity, from a town to an address to a warehouse location.  Usually mappable." .
 
 vf:primaryLocation a        owl:ObjectProperty ;
         rdfs:label          "primary location" ;
         rdfs:domain         foaf:Agent ;
-        #rdfs:range          vf:Location ;
+        rdfs:range          vf:Location ;
         vs:term_status      "unstable" ;
         rdfs:comment        "The main place an agent is located, often an address where activities occur and mail can be sent. This is usually a mappable geographic location.  It also could be a website address, as in the case of agents who have no physical location." .
+
+vf:observedLocation a       owl:ObjectProperty ;
+        rdfs:label          "observed location" ;
+        rdfs:domain         vf:EconomicEvent ;
+        rdfs:range          vf:Location ;
+        vs:term_status      "unstable" ;
+        rdfs:comment        "The place where an economic event occurs.  Usually mappable." .
 
 vf:image a                  owl:DatatypeProperty ;
         vs:term_status      "unstable" ;


### PR DESCRIPTION
Added observedLocation to EconomicEvent, per discussion https://github.com/valueflows/valueflows/issues/486.  Also put vf:Location back for now.  We can swap in another vocab for this if we want.  I'll add a few property references from other vocabs, unless you get there first @elf-pavlik .