### PR TITLE
clarify resource spec vs classif

### DIFF
--- a/docs/introduction/resources.md
+++ b/docs/introduction/resources.md
@@ -10,27 +10,30 @@ And we want knowledge to be freely available.
 
 Also, we prefer to think of use value, but economic resources also often have exchange value.
 
-#### The difference between a resource and its specification or classification
+#### The difference between a resource and its specification/classification(s)
 
-An economic resource is observable.  Its specification or classification defines what type of thing the economic resource is.
+An economic resource is observable.  Its specification or classification defines what kind of thing the economic resource is.
 
-So, for example, most things offered for sale on an e-commerce site are specifications, which can be searched using classifications.
-The one in a box delivered to your door is a resource.
+So, for example, most things offered for sale on an e-commerce site are specifications, which can be searched using classifications. The one in a box delivered to your door is a resource.
 
 Or the description of the book entitled "The Power of Babel: A Natural History of Language", ISBN ISBN-13: 978-0060520854,
 is a specification. Your library may have two copies that you can check out. Those are resources.
 
-Resource classifications are a Taxonomy. That means they can be defined very broadly and generally and maybe vaguely, or they can be defined very narrowly, but fit into broader classifications. 
+#### The difference between a resource specification and a resource classification
+
+An economic resource or a flow can have only *resource specification*, defined by `resourceConformsTo`.  This defines the lowest level useful type or kind of the resource that is needed. It can be defined within the ValueFlows vocabulary as a ResourceSpecification, or can refer to a specification elsewhere using a uri.  Note that often taxonomies and other references on the web can define very specific resource specifications.
+
+An economic resource or a flow can have any number of *resource classifications*.  They are used to filter, match, or group economic resources.  Resource classifications can be part of a taxonomy. That means they can be defined very broadly and generally and maybe vaguely, or they can be defined very narrowly, but fit into broader classifications. 
 
 So, for example, you may want an apple. Or you may want a green apple. Or you may want a Granny Smith apple.
 
 Or, Herb is the parent classification of Anise Hyssop, Goldenrod, Nettles, Red Clover, etc.  Besides its usefulness in understanding taxonomies of resource types, this can be useful when one can define a general recipe that will work for many more specific kinds of resources.
 
-People can use the multitude of existing taxonomies for resource classifications, or can also create their own as needed.  The references to resource classifications are uri's, and not covered inside ValueFlows.
+People can use the multitude of existing taxonomies for resource classifications, or can also create their own as needed. 
 
-The ResourceSpecification is part of ValueFlows, and part of the recipe structure. 
-It is used when you need to have more definition and configurability than you can 
-find in a simple taxonomy, whether there is a recipe or not.
+Resource classifications can also use other schemes, like facets or tags.
+
+The references to resource classifications are uri's, and not covered inside ValueFlows.
 
 #### Identification and Behaviors of Resources
 

--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -484,7 +484,7 @@ vf:classifiedAs
         rdfs:domain         owl:Thing ;
         rdfs:range          owl:Thing ;
         vs:term_status      "unstable" ;
-        rdfs:comment        "References a concept in a common taxonomy or other classification scheme for purposes of categorization." .
+        rdfs:comment        "References a concept in a common taxonomy or other classification scheme for purposes of categorization or grouping." .
 
 vf:resourceClassifiedAs
         a                   owl:ObjectProperty ;
@@ -492,7 +492,7 @@ vf:resourceClassifiedAs
         rdfs:domain         [ owl:unionOf (vf:ResourceSpecification vf:Intent vf:Commitment vf:EconomicEvent vf:RecipeFlow vf:Claim) ] ;
         rdfs:range          owl:Thing ;
         vs:term_status      "unstable" ;
-        rdfs:comment        "References a concept in a common taxonomy or other classification scheme for purposes of categorization." .
+        rdfs:comment        "References a concept in a common taxonomy or other classification scheme for purposes of categorization or grouping." .
 
 vf:processClassifiedAs
         a                   owl:ObjectProperty ;
@@ -500,15 +500,15 @@ vf:processClassifiedAs
         rdfs:domain         vf:RecipeProcess ;
         rdfs:range          owl:Thing ;
         vs:term_status      "unstable" ;
-        rdfs:comment        "References a concept in a common taxonomy or other classification scheme for purposes of categorization." .
+        rdfs:comment        "References a concept in a common taxonomy or other classification scheme for purposes of categorization or grouping." .
 
 vf:resourceConformsTo
         a                   owl:ObjectProperty ;
         rdfs:label          "resource conforms to" ;
         rdfs:domain         [ owl:unionOf (vf:Commitment vf:EconomicResource vf:Intent vf:RecipeFlow vf:EconomicEvent vf:Claim ) ] ;
-        rdfs:range          vf:ResourceSpecification ;
+        rdfs:range          [ owl:unionOf (vf:ResourceSpecification owl:Thing) ] ;
         vs:term_status      "unstable" ;
-        rdfs:comment        "The primary resource knowledge specification or definition of an existing or potential resource." .
+        rdfs:comment        "The primary resource specification or definition of an existing or potential economic resource. A resource will have only one, as this specifies exactly what the resource is. If not a vf:ResourceSpecification, this can be a link to another specification." .
 
 vf:clauseOf a               owl:ObjectProperty ;
         rdfs:label          "clause of" ;


### PR DESCRIPTION
I think this clarifies the resource classification and resource specification difference.  I got this idea from reading some of McCarthy's recent writings.  This seems a lot cleaner conceptually than something sort of like "it is on the web or it is either part of a recipe or not on the web".  From his doc:

* typify - the association between a concrete entity and the abstract specification of its essential and computed properties.  Typifying a concrete object, person, or occurrence attempts to specify properties that capture its archetypal essence.  This definition derives from Platonic philosophy.
* group - the association between a concrete entity and another concrete class that defines its aggregated and computed properties.  Typing and grouping are abstraction mechanisms that at the margin are very close to each other.  In the REA ontology, we consider grouping as that set of aggregation associations that lacks the archetypal essence validation.

RDF question:  I put ResourceSpecification and owl:Thing both on the range of resourceConformsTo.  Seems not quite right, but I do want to call out ResourceSpecification.  Also wondering if instead of owl:Thing, we should be using a uri for this and for resourceClassifiedAs?

