### PR TITLE
separated out specifications from recipe

### DIFF
--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -519,6 +519,14 @@ vf:processClassifiedAs
         vs:term_status      "unstable" ;
         rdfs:comment        "References a concept in a common taxonomy or other classification scheme for purposes of categorization." .
 
+vf:processConformsTo
+        a                   owl:ObjectProperty ;
+        rdfs:label          "process conforms to" ;
+        rdfs:domain         vf:RecipeProcess ;
+        rdfs:range          vf:ProcessSpecification ;
+        vs:term_status      "unstable" ;
+        rdfs:comment        "The standard specification or definition of a process."
+
 vf:resourceConformsTo
         a                   owl:ObjectProperty ;
         rdfs:label          "resource conforms to" ;

--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -35,6 +35,11 @@ vf:AgentRelationshipRole  a  owl:Class ;
 #        rdfs:label         "vf:Recipe" ;
 #        rdfs:comment       "Recipes contain all the info required to create or improve or move a resource." .
 
+vf:RecipeResource a         owl:Class ;
+        rdfs:label          "vf:RecipeResource" ;
+        vs:term_status      "unstable" ;
+        rdfs:comment        "Specifies the resource as part of a recipe, for use in planning from recipe." .
+
 vf:ResourceSpecification a  owl:Class ;
         rdfs:label          "vf:ResourceSpecification" ;
         vs:term_status      "unstable" ;
@@ -44,6 +49,11 @@ vf:RecipeProcess a          owl:Class ;
         rdfs:label          "vf:RecipeProcess" ;
         vs:term_status      "unstable" ;
         rdfs:comment        "Specifies the process part of a recipe for use in planning from recipe." .
+
+vf:ProcessSpecification a   owl:Class ;
+        rdfs:label          "vf:ProcessSpecification" ;
+        vs:term_status      "unstable" ;
+        rdfs:comment        "Specifies the kind of process." .
 
 vf:RecipeFlow a             owl:Class ;
         rdfs:label          "vf:RecipeFlow" ;
@@ -434,12 +444,19 @@ vf:substitutable a        owl:DatatypeProperty ;
         vs:term_status      "unstable" ;
         rdfs:comment        "Defines if any resource of that type can be freely substituted for any other resource of that type when used, consumed, traded, etc." .
 
-vf:unit a                   owl:ObjectProperty ;
-        rdfs:label          "unit" ;
+vf:defaultUnit a            owl:ObjectProperty ;
+        rdfs:label          "default unit" ;
         rdfs:domain         vf:ResourceSpecification ;
         rdfs:range          qudt:unit ;
         vs:term_status      "unstable" ;
         rdfs:comment        "The unit expected for this resource specification as a default." .
+
+vf:unit a                   owl:ObjectProperty ;
+        rdfs:label          "unit" ;
+        rdfs:domain         vf:RecipeResource ;
+        rdfs:range          qudt:unit ;
+        vs:term_status      "unstable" ;
+        rdfs:comment        "The unit used for this resource in the recipe." .
 
 # TODO: need to define this, something like currency, inventory, skill, service; may be other aspects too.
 #vf:resourceCategory a    owl:ObjectProperty ;
@@ -474,9 +491,9 @@ vf:basedOn
         a                   owl:ObjectProperty ;
         rdfs:label          "based on" ;
         rdfs:domain         vf:Process ;
-        rdfs:range          vf:RecipeProcess ;
+        rdfs:range          vf:ProcessSpecification ;
         vs:term_status      "unstable" ;
-        rdfs:comment        "The recipe definition or specification for a process." .
+        rdfs:comment        "The recipe definition or standard specification for a process." .
 
 vf:classifiedAs
         a                   owl:ObjectProperty ;
@@ -489,7 +506,7 @@ vf:classifiedAs
 vf:resourceClassifiedAs
         a                   owl:ObjectProperty ;
         rdfs:label          "resource classified as" ;
-        rdfs:domain         [ owl:unionOf (vf:ResourceSpecification vf:Intent vf:Commitment vf:EconomicEvent vf:RecipeFlow vf:Claim) ] ;
+        rdfs:domain         [ owl:unionOf (vf:RecipeResource vf:Intent vf:Commitment vf:EconomicEvent vf:RecipeFlow vf:Claim) ] ;
         rdfs:range          owl:Thing ;
         vs:term_status      "unstable" ;
         rdfs:comment        "References a concept in a common taxonomy or other classification scheme for purposes of categorization." .
@@ -505,10 +522,26 @@ vf:processClassifiedAs
 vf:resourceConformsTo
         a                   owl:ObjectProperty ;
         rdfs:label          "resource conforms to" ;
-        rdfs:domain         [ owl:unionOf (vf:Commitment vf:EconomicResource vf:Intent vf:RecipeFlow vf:EconomicEvent vf:Claim ) ] ;
+        rdfs:domain         [ owl:unionOf (vf:Commitment vf:Intent vf:RecipeResource vf:EconomicEvent vf:Claim ) ] ;
         rdfs:range          vf:ResourceSpecification ;
         vs:term_status      "unstable" ;
         rdfs:comment        "The primary resource knowledge specification or definition of an existing or potential resource." .
+
+vf:conformsTo
+        a                   owl:ObjectProperty ;
+        rdfs:label          "conforms to" ;
+        rdfs:domain         vf:EconomicResource ;
+        rdfs:range          vf:ResourceSpecification ;
+        vs:term_status      "unstable" ;
+        rdfs:comment        "The primary resource knowledge specification or definition of an existing or potential resource." .
+
+vf:recipeFlowResource
+        a                   owl:ObjectProperty ;
+        rdfs:label          "recipe flow resource" ;
+        rdfs:domain         vf:RecipeFlow ;
+        rdfs:range          vf:RecipeResource ;
+        vs:term_status      "unstable" ;
+        rdfs:comment        "The resource definition referenced by this flow in the recipe." .
 
 vf:clauseOf a               owl:ObjectProperty ;
         rdfs:label          "clause of" ;

--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -525,7 +525,7 @@ vf:processConformsTo
         rdfs:domain         vf:RecipeProcess ;
         rdfs:range          vf:ProcessSpecification ;
         vs:term_status      "unstable" ;
-        rdfs:comment        "The standard specification or definition of a process."
+        rdfs:comment        "The standard specification or definition of a process." .
 
 vf:resourceConformsTo
         a                   owl:ObjectProperty ;


### PR DESCRIPTION
Discussion here: https://github.com/valueflows/valueflows/issues/521.

Pulled out both ResourceSpecification and new ProcessSpecification from the recipe, to support them being in different modules in VF apps.  And in modeling terms to separate the concerns of the specifications and the recipe anyhow, just exposed by the app modularization work.