### PR TITLE
Json schema using repo

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -36,7 +36,7 @@
 * [Classes and Properties](specification/protege-spec.md)
 * [External terms](specification/external-terms.md)
 * [Graphql Reference](https://github.com/valueflows/vf-graphql/tree/master/lib/schemas)
-* [JSON-schema Reference](specification/json-schema-ref.md)
+* [JSON-schema Reference](https://github.com/valueflows/vf-json-schema/tree/master/schemas)
 
 ## Examples
 

--- a/docs/specification/json-schema-ref.md
+++ b/docs/specification/json-schema-ref.md
@@ -33,7 +33,7 @@ The following are the classes needed for a ValueFlows implementation, in json-sc
 
 #### Action
 
-[import, lang:"json"](../../../opt/build/vf-json-schema/schemas/Action.json)
+[import, lang:"json"](https://github.com/valueflows/vf-json-schema/blob/master/schemas/Action.json)
 
 #### Agent
 

--- a/docs/specification/protege-spec.md
+++ b/docs/specification/protege-spec.md
@@ -14,4 +14,4 @@ For the current rdf turtle file reference, [click here](https://raw.githubuserco
 
 ### Complete References
 
-For a complete reference, see the [UML diagram](https://valueflo.ws/specification/diagrams/uml.html), which also documents the appropriate rdf namespace for each element.  Also the [graphql reference](https://github.com/valueflows/vf-graphql/tree/master/lib/schemas) includes the entire vocabulary in a non-rdf format, as does the [json-schema reference](https://valueflo.ws/specification/json-schema-ref.html).
+For a complete reference, see the [UML diagram](https://valueflo.ws/specification/diagrams/uml.html), which also documents the appropriate rdf namespace for each element.  Also the [graphql reference](https://github.com/valueflows/vf-graphql/tree/master/lib/schemas) includes the entire vocabulary in a non-rdf format, as does the [json-schema reference](https://github.com/valueflows/vf-json-schema/tree/master/schemas).


### PR DESCRIPTION
Removed page to show json-schemas, can return to when more time.  Linking to the json-schema repo instead.