### PR TITLE
adding resource primary agent

### DIFF
--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -344,7 +344,7 @@ vf:primaryAccountable a      owl:ObjectProperty ;
         rdfs:domain         vf:EconomicResource ;
         rdfs:range          vf:Agent ;
         vs:term_status      "unstable" ;
-        rdfs:comment        "The agent currently with primary rights and responsibilites for the economic resource. This agent will normally do the accounting for the resource." .
+        rdfs:comment        "The agent currently with primary rights and responsibilites for the economic resource.  It is the agent that includes the resource in their accounting reports or inventory." .
 
 vf:hasBeginning a           owl:DatatypeProperty ;
         rdfs:domain         time:TemporalEntity ;

--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -339,6 +339,13 @@ vf:containedIn a            owl:ObjectProperty ;
         vs:term_status      "unstable" ;
         rdfs:comment        "Used when a stock economic resource contains units also defined as economic resources." .
 
+vf:primaryAccountable a      owl:ObjectProperty ;
+        rdfs:label          "primary accountable" ;
+        rdfs:domain         vf:EconomicResource ;
+        rdfs:range          vf:Agent ;
+        vs:term_status      "unstable" ;
+        rdfs:comment        "The agent currently with primary rights and responsibilites for the economic resource. This agent will normally do the accounting for the resource." .
+
 vf:hasBeginning a           owl:DatatypeProperty ;
         rdfs:domain         time:TemporalEntity ;
         rdfs:domain         [ owl:unionOf (

--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -344,7 +344,7 @@ vf:primaryAccountable a      owl:ObjectProperty ;
         rdfs:domain         vf:EconomicResource ;
         rdfs:range          vf:Agent ;
         vs:term_status      "unstable" ;
-        rdfs:comment        "The agent currently with primary rights and responsibilites for the economic resource.  It is the agent that includes the resource in their accounting reports or inventory." .
+        rdfs:comment        "The agent currently with primary rights and responsibilites for the economic resource. It is the agent that is associated with the accountingQuantity of the economic resource." .
 
 vf:hasBeginning a           owl:DatatypeProperty ;
         rdfs:domain         time:TemporalEntity ;


### PR DESCRIPTION
Added accounting agent to the resource.  This is "owner" and whatever owner becomes in a less owner-oriented economic system, so I'm avoiding the term.  It is the agent that includes the resource in their accounting reports or UI as part of their inventory. 

Looking for the best name, suggestions welcome.  I have it as primaryAccountable.  Have also toyed with primaryAccounting, primaryResponsible.  Thought I had a better name earlier in discussion with @jvanbockryck but can't find it now.

This is a simple version of agent-resource relationships, user defined, such as we have used in NRP/OCP.  Right now I don't think we want that whole mechanism.  If we add something like that later, this will still be useful as a direct filter on resources.