### PR TITLE
Discussion PR: remove `vf:notApplicable` and `vf:PairsWith` in owl schema

### DIFF
--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -347,7 +347,7 @@ vf:containedIn a            owl:ObjectProperty ;
 vf:primaryAccountable a      owl:ObjectProperty ;
         rdfs:label          "primary accountable" ;
         rdfs:domain         vf:EconomicResource ;
-        rdfs:range          vf:Agent ;
+        rdfs:range          foaf:Agent ;
         vs:term_status      "unstable" ;
         rdfs:comment        "The agent currently with primary rights and responsibilites for the economic resource. It is the agent that is associated with the accountingQuantity of the economic resource." .
 

--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -33,11 +33,6 @@ vf:Action  a                 owl:Class ;
         vs:term_status       "testing" ;
         rdfs:comment         "An action verb defining the kind of flow and its behavior." .
 
-vf:PairsWith a              owl:Class ;
-        rdfs:comment        "The action that should be included on the other direction of the process, for example accept with modify; also includes not applicable." ;
-        rdfs:label          "vf:PairsWith" ;
-        vs:term_status      "unstable" .
-
 vf:InputOutput a            owl:Class ;
         rdfs:comment        "The action is an input or output of a process, or not related to a process." ;
         rdfs:label          "vf:InputOutput" ;
@@ -849,7 +844,6 @@ vf:accept a                 owl:NamedIndividual ,
 vf:consume a                owl:NamedIndividual ,
                             vf:Action ;
         vf:inputOutput      vf:input ;
-        vf:pairsWith        vf:notApplicable ;
         vf:resourceEffect   vf:decrement ;
         rdfs:comment        "For example an ingredient or component composed into the output, after the process the ingredient is gone." ;
         rdfs:label          "consume" ;
@@ -858,7 +852,6 @@ vf:consume a                owl:NamedIndividual ,
 vf:cite a                   owl:NamedIndividual ,
                             vf:Action ;
         vf:inputOutput      vf:input ;
-        vf:pairsWith        vf:notApplicable ;
         vf:resourceEffect   vf:noEffect ;
         rdfs:comment        "For example a design file, neither used nor consumed, the file remains available at all times." ;
         rdfs:label          "cite" ;
@@ -867,7 +860,6 @@ vf:cite a                   owl:NamedIndividual ,
 vf:deliver-service a        owl:NamedIndividual ,
                             vf:Action ;
         vf:inputOutput      vf:output ;
-        vf:pairsWith        vf:notApplicable ;
         vf:resourceEffect   vf:noEffect ;
         rdfs:comment        "New service produced and delivered (a service implies that an agent actively receives the service)." ;
         rdfs:label          "deliver-service" ;
@@ -885,8 +877,6 @@ vf:dropoff a                owl:NamedIndividual ,
 
 vf:lower a                  owl:NamedIndividual ,
                             vf:Action ;
-        vf:inputOutput      vf:notApplicable ;
-        vf:pairsWith        vf:notApplicable ;
         vf:resourceEffect   vf:decrement ;
         rdfs:comment        "Adjusts a quantity down based on a beginning balance or inventory count." ;
         rdfs:label          "lower" ;
@@ -904,8 +894,6 @@ vf:modify a                 owl:NamedIndividual ,
 
 vf:move a                   owl:NamedIndividual ,
                             vf:Action ;
-        vf:inputOutput      vf:notApplicable ;
-        vf:pairsWith        vf:notApplicable ;
         vf:resourceEffect   vf:decrementIncrement ;
         rdfs:comment        "Change location and possibly identifier, if location is part of the identification, of a resource with no change of agent rights or possession." ;
         rdfs:label          "move" ;
@@ -924,7 +912,6 @@ vf:pickup a                 owl:NamedIndividual ,
 vf:produce a                owl:NamedIndividual ,
                             vf:Action ;
         vf:inputOutput      vf:output ;
-        vf:pairsWith        vf:notApplicable ;
         vf:resourceEffect   vf:increment ;
         rdfs:comment        "New resource was created in that process or an existing stock resource was added to." ;
         rdfs:label          "produce" ;
@@ -932,8 +919,6 @@ vf:produce a                owl:NamedIndividual ,
 
 vf:raise a                  owl:NamedIndividual ,
                             vf:Action ;
-        vf:inputOutput      vf:notApplicable ;
-        vf:pairsWith        vf:notApplicable ;
         vf:resourceEffect   vf:increment ;
         rdfs:comment        "Adjusts a quantity up based on a beginning balance or inventory count." ;
         rdfs:label          "raise" ;
@@ -941,8 +926,6 @@ vf:raise a                  owl:NamedIndividual ,
 
 vf:transfer-all-rights a    owl:NamedIndividual ,
                             vf:Action ;
-        vf:inputOutput      vf:notApplicable ;
-        vf:pairsWith        vf:notApplicable ;
         vf:resourceEffect   vf:decrementIncrement ;
         rdfs:comment        "Give full (in the human realm) rights and responsibilities to another agent, without transferring physical custody." ;
         rdfs:label          "transfer-all-rights" ;
@@ -950,8 +933,6 @@ vf:transfer-all-rights a    owl:NamedIndividual ,
 
 vf:transfer a               owl:NamedIndividual ,
                             vf:Action ;
-        vf:inputOutput      vf:notApplicable ;
-        vf:pairsWith        vf:notApplicable ;
         vf:resourceEffect   vf:decrementIncrement ;
         rdfs:comment        "Give full rights and responsibilities plus physical custody." ;
         rdfs:label          "transfer" ;
@@ -959,8 +940,6 @@ vf:transfer a               owl:NamedIndividual ,
 
 vf:transfer-custody a       owl:NamedIndividual ,
                             vf:Action ;
-        vf:inputOutput      vf:notApplicable ;
-        vf:pairsWith        vf:notApplicable ;
         vf:resourceEffect   vf:decrementIncrement ;
         rdfs:comment        "Give physical custody and control of a resource, without full accounting or ownership rights." ;
         rdfs:label          "transfer-custody" ;
@@ -969,7 +948,6 @@ vf:transfer-custody a       owl:NamedIndividual ,
 vf:use a                    owl:NamedIndividual ,
                             vf:Action ;
         vf:inputOutput      vf:input ;
-        vf:pairsWith        vf:notApplicable ;
         vf:resourceEffect   vf:noEffect ;
         rdfs:comment        "For example a tool used in process; after the process, the tool still exists." ;
         rdfs:label          "use" ;
@@ -978,7 +956,6 @@ vf:use a                    owl:NamedIndividual ,
 vf:work a                   owl:NamedIndividual ,
                             vf:Action ;
         vf:inputOutput      vf:input ;
-        vf:pairsWith        vf:notApplicable ;
         vf:resourceEffect   vf:noEffect ;
         rdfs:comment        "Labor power applied to a process." ;
         rdfs:label          "work" ;
@@ -1016,13 +993,6 @@ vf:input a                  owl:NamedIndividual ,
                             vf:InputOutput ;
         rdfs:comment        "This kind of flow can be an input to a process." ;
         rdfs:label          "input" ;
-        vs:term_status      "unstable" .
-
-vf:notApplicable a          owl:NamedIndividual ,
-                            vf:InputOutput ,
-                            vf:PairsWith ;
-        rdfs:comment        "This property is not applicable to this kind of flow." ;
-        rdfs:label          "not applicable" ;
         vs:term_status      "unstable" .
 
 vf:output a                  owl:NamedIndividual ,

--- a/release-doc-in-process/all_vf.TTL
+++ b/release-doc-in-process/all_vf.TTL
@@ -832,8 +832,7 @@ vf:resourceEffect a         owl:ObjectProperty ;
 # Actions
 
 vf:accept a                 owl:NamedIndividual ,
-                            vf:Action ,
-                            vf:PairsWith ;
+                            vf:Action ;
         vf:inputOutput      vf:input ;
         vf:pairsWith        vf:modify ;
         vf:resourceEffect   vf:noEffect ;
@@ -866,8 +865,7 @@ vf:deliver-service a        owl:NamedIndividual ,
         vs:term_status      "unstable" .
 
 vf:dropoff a                owl:NamedIndividual ,
-                            vf:Action ,
-                            vf:PairsWith ;
+                            vf:Action ;
         vf:inputOutput      vf:output ;
         vf:pairsWith        vf:pickup ;
         vf:resourceEffect   vf:noEffect ;
@@ -883,8 +881,7 @@ vf:lower a                  owl:NamedIndividual ,
         vs:term_status      "unstable" .
 
 vf:modify a                 owl:NamedIndividual ,
-                            vf:Action ,
-                            vf:PairsWith ;
+                            vf:Action ;
         vf:inputOutput      vf:output ;
         vf:pairsWith        vf:accept ;
         vf:resourceEffect   vf:noEffect ;
@@ -900,8 +897,7 @@ vf:move a                   owl:NamedIndividual ,
         vs:term_status      "unstable" .
 
 vf:pickup a                 owl:NamedIndividual ,
-                            vf:Action ,
-                            vf:PairsWith ;
+                            vf:Action ;
         vf:inputOutput      vf:input ;
         vf:pairsWith        vf:dropoff ;
         vf:resourceEffect   vf:noEffect ;


### PR DESCRIPTION
Hi! After [this pr](https://github.com/valueflows/valueflows/pull/619) and the [included discussion](https://github.com/valueflows/valueflows/issues/615#issuecomment-613091091) I started working with the vf model more (converting to rust) and realized something I'd like to bring up for discussion. Keep in mind, these modifications took all of 30s to make, so if ultimately the decision is made to reject this PR I will not be hurt at all.

Effectively I think it makes sense to remove `vf:notApplicable` and `vf:PairsWith`. When converting the rdf spec into rust, I ran into issues where essentially I was hardcoding logic like "if this contains `vf:notApplicable` then the type should be able to return NULL (`None` in rust)" and "if we encounter `vf:PairsWith` ignore it entirely because in reality it's a subset of `vf:Action` which is already defined."

Once logic like this starts sneaking, my first instinct is to ask "am I doing something wrong?"

Then I realized a way this could be done without hardcoding. Remove all instances of `vf:notApplicable`:

```ttl
vf:transfer-custody a       owl:NamedIndividual ,
                            vf:Action ;
        vf:inputOutput      vf:notApplicable ;
        vf:pairsWith        vf:notApplicable ;
        vf:resourceEffect   vf:decrementIncrement ;
        rdfs:comment        "Give physical custody and control of a resource, without full accounting or ownership rights." ;
        rdfs:label          "transfer-custody" ;
        vs:term_status      "unstable" .

vf:use a                    owl:NamedIndividual ,
                            vf:Action ;
        vf:inputOutput      vf:input ;
        vf:pairsWith        vf:notApplicable ;
        vf:resourceEffect   vf:noEffect ;
        rdfs:comment        "For example a tool used in process; after the process, the tool still exists." ;
        rdfs:label          "use" ;
        vs:term_status      "unstable" .
```

becomes 

```ttl
vf:transfer-custody a       owl:NamedIndividual ,
                            vf:Action ;
        vf:resourceEffect   vf:decrementIncrement ;
        rdfs:comment        "Give physical custody and control of a resource, without full accounting or ownership rights." ;
        rdfs:label          "transfer-custody" ;
        vs:term_status      "unstable" .

vf:use a                    owl:NamedIndividual ,
                            vf:Action ;
        vf:inputOutput      vf:input ;
        vf:resourceEffect   vf:noEffect ;
        rdfs:comment        "For example a tool used in process; after the process, the tool still exists." ;
        rdfs:label          "use" ;
        vs:term_status      "unstable" .
```

Given that the `ObjectProperties` for `vf:pairsWith` and `vf:inputOutput` are defined on the enum, the implementor can now say `Action::TransferCustody` should be able to return a `pairs_with()` or `input_output()` value *but they are not defined in all cases* therefor it makes sense to allow the return types to be nullable (which is effectively what the hardcoded `vf:notApplicable` logic was doing anyway).

By extension, if `vf:notApplicable` becomes redundant, `vf:PairsWith` outlives its usefulness as well (since it only exists to union `vf:notApplicable` with a subset of `vf:Action`).

The only part that I don't know is if this is idiomatic owl/rdf/etc or if this would hurt the undertanding of others trying to parse the schema. If you define an `ObjectProperty` on an enum value, is it "ok" for the enum values to not return a value for that property?

Hopefully this all makes sense, I can expand further if needed, and like I said, want this to be more of a discussion. I thought a PR instead of an issue might be appropriate since I know exactly what change I'm envisioning.

Thanks!

